### PR TITLE
日付入力の共通化とDateInputコンポーネント実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@hookform/resolvers": "^5.2.1",
-        "@react-native-community/datetimepicker": "^8.4.4",
+        "@react-native-community/datetimepicker": "^8.4.1",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2846,9 +2846,9 @@
       }
     },
     "node_modules/@react-native-community/datetimepicker": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.4.tgz",
-      "integrity": "sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.1.tgz",
+      "integrity": "sha512-DrK+CUS5fZnz8dhzBezirkzQTcNDdaXer3oDLh0z4nc2tbdIdnzwvXCvi8IEOIvleoc9L95xS5tKUl0/Xv71Mg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@hookform/resolvers": "^5.2.1",
-    "@react-native-community/datetimepicker": "^8.4.4",
+    "@react-native-community/datetimepicker": "^8.4.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",

--- a/frontend/src/features/reports/components/DateInput.tsx
+++ b/frontend/src/features/reports/components/DateInput.tsx
@@ -44,8 +44,10 @@ export default function DateInput({ value, onChange }: DateInputProps) {
 
   return (
     <DateTimePicker
+      key={value}
       value={value ? new Date(value) : new Date()}
       mode="date"
+      themeVariant="light"
       onChange={handleNativeDateChange}
     />
   );

--- a/frontend/src/features/reports/components/DateInput.tsx
+++ b/frontend/src/features/reports/components/DateInput.tsx
@@ -1,0 +1,52 @@
+import { Platform } from "react-native";
+import DateTimePicker from "@react-native-community/datetimepicker";
+
+interface DateInputProps {
+  value?: string;
+  onChange: (dateString?: string) => void;
+}
+
+export default function DateInput({ value, onChange }: DateInputProps) {
+  const handleWebDateChange = (e: any) => {
+    const dateString = e.target.value;
+    onChange(dateString || undefined);
+  };
+
+  const handleWebDateClick = (e: any) => {
+    try {
+      if (e.isTrusted) {
+        e.target.showPicker?.();
+      }
+    } catch (error) {
+      console.log("showPicker not available, using browser default");
+    }
+  };
+
+  const handleNativeDateChange = (event: any, selectedDate?: Date) => {
+    if (event.type === "set" && selectedDate) {
+      const dateString = selectedDate.toISOString().split("T")[0];
+      onChange(dateString);
+    }
+  };
+
+  if (Platform.OS === "web") {
+    return (
+      <input
+        type="date"
+        value={value || ""}
+        onChange={handleWebDateChange}
+        onClick={handleWebDateClick}
+        className="w-full border-none outline-none text-base text-gray-800 bg-transparent cursor-pointer"
+        placeholder="選択してください"
+      />
+    );
+  }
+
+  return (
+    <DateTimePicker
+      value={value ? new Date(value) : new Date()}
+      mode="date"
+      onChange={handleNativeDateChange}
+    />
+  );
+}

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -167,7 +167,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     <DateTimePicker
                       value={filters.startDate ? new Date(filters.startDate) : new Date()}
                       mode="date"
-                      display="compact"
+                      display="default"
                       onChange={(event, selectedDate) => {
                         if (event.type === 'set' && selectedDate) {
                           const dateString = selectedDate.toISOString().split('T')[0];
@@ -176,6 +176,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                             startDate: dateString,
                           });
                         }
+                        // Calendar automatically closes after selection with 'default' display
                       }}
                       style={{ alignSelf: 'flex-start' }}
                     />
@@ -221,7 +222,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     <DateTimePicker
                       value={filters.endDate ? new Date(filters.endDate) : new Date()}
                       mode="date"
-                      display="compact"
+                      display="default"
                       onChange={(event, selectedDate) => {
                         if (event.type === 'set' && selectedDate) {
                           const dateString = selectedDate.toISOString().split('T')[0];
@@ -230,6 +231,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                             endDate: dateString,
                           });
                         }
+                        // Calendar automatically closes after selection with 'default' display
                       }}
                       style={{ alignSelf: 'flex-start' }}
                     />

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -31,8 +31,6 @@ const statusOptions = [
 export default function ReportFilter({ filters, onFiltersChange, onClearFilters }: ReportFilterProps) {
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [showDatePicker, setShowDatePicker] = useState<"start" | "end" | null>(null);
-  const [tempDate, setTempDate] = useState(new Date());
 
   const formatDateForDisplay = (dateString?: string) => {
     if (!dateString) return "選択してください";
@@ -165,18 +163,22 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  <TouchableOpacity
-                    onPress={() => {
-                      setTempDate(filters.startDate ? new Date(filters.startDate) : new Date());
-                      setShowDatePicker("start");
-                    }}
-                    className="flex-row items-center"
-                  >
-                    <Text className="text-gray-800 flex-1">
-                      {formatDateForDisplay(filters.startDate)}
-                    </Text>
-                    <Ionicons name="calendar-outline" size={16} color="#6B7280" />
-                  </TouchableOpacity>
+                  DateTimePicker && (
+                    <DateTimePicker
+                      value={filters.startDate ? new Date(filters.startDate) : new Date()}
+                      mode="date"
+                      display="compact"
+                      onChange={(event, selectedDate) => {
+                        if (event.type === 'set' && selectedDate) {
+                          const dateString = selectedDate.toISOString().split('T')[0];
+                          onFiltersChange({
+                            ...filters,
+                            startDate: dateString,
+                          });
+                        }
+                      }}
+                    />
+                  )
                 )}
               </View>
               
@@ -214,18 +216,22 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  <TouchableOpacity
-                    onPress={() => {
-                      setTempDate(filters.endDate ? new Date(filters.endDate) : new Date());
-                      setShowDatePicker("end");
-                    }}
-                    className="flex-row items-center"
-                  >
-                    <Text className="text-gray-800 flex-1">
-                      {formatDateForDisplay(filters.endDate)}
-                    </Text>
-                    <Ionicons name="calendar-outline" size={16} color="#6B7280" />
-                  </TouchableOpacity>
+                  DateTimePicker && (
+                    <DateTimePicker
+                      value={filters.endDate ? new Date(filters.endDate) : new Date()}
+                      mode="date"
+                      display="compact"
+                      onChange={(event, selectedDate) => {
+                        if (event.type === 'set' && selectedDate) {
+                          const dateString = selectedDate.toISOString().split('T')[0];
+                          onFiltersChange({
+                            ...filters,
+                            endDate: dateString,
+                          });
+                        }
+                      }}
+                    />
+                  )
                 )}
               </View>
             </View>
@@ -288,31 +294,6 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
         </TouchableOpacity>
       </Modal>
 
-      {/* DateTimePicker for iOS/Android */}
-      {showDatePicker && Platform.OS !== 'web' && DateTimePicker && (
-        <DateTimePicker
-          value={tempDate}
-          mode="date"
-          display="default"
-          onChange={(event, selectedDate) => {
-            setShowDatePicker(null);
-            if (event.type === 'set' && selectedDate) {
-              const dateString = selectedDate.toISOString().split('T')[0];
-              if (showDatePicker === "start") {
-                onFiltersChange({
-                  ...filters,
-                  startDate: dateString,
-                });
-              } else if (showDatePicker === "end") {
-                onFiltersChange({
-                  ...filters,
-                  endDate: dateString,
-                });
-              }
-            }
-          }}
-        />
-      )}
     </View>
   );
 }

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -33,6 +33,9 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [tempDate, setTempDate] = useState(new Date());
+  
+  // Force re-render when showDatePicker changes
+  const [pickerKey, setPickerKey] = useState(0);
 
   const formatDateForDisplay = (dateString?: string) => {
     if (!dateString) return "選択してください";
@@ -175,7 +178,11 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       onPress={() => {
                         const currentDate = filters.startDate ? new Date(filters.startDate) : new Date();
                         setTempDate(currentDate);
-                        setShowDatePicker("start");
+                        setPickerKey(prev => prev + 1);
+                        // Use setTimeout to ensure state is updated before showing picker
+                        setTimeout(() => {
+                          setShowDatePicker("start");
+                        }, 0);
                       }}
                     >
                       <Text className="text-gray-800">
@@ -186,6 +193,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     {/* DateTimePicker for immediate display */}
                     {showDatePicker === "start" && DateTimePicker && (
                       <DateTimePicker
+                        key={`start-${pickerKey}`}
                         value={tempDate}
                         mode="date"
                         display="default"
@@ -250,7 +258,11 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       onPress={() => {
                         const currentDate = filters.endDate ? new Date(filters.endDate) : new Date();
                         setTempDate(currentDate);
-                        setShowDatePicker("end");
+                        setPickerKey(prev => prev + 1);
+                        // Use setTimeout to ensure state is updated before showing picker
+                        setTimeout(() => {
+                          setShowDatePicker("end");
+                        }, 0);
                       }}
                     >
                       <Text className="text-gray-800">
@@ -261,6 +273,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     {/* DateTimePicker for immediate display */}
                     {showDatePicker === "end" && DateTimePicker && (
                       <DateTimePicker
+                        key={`end-${pickerKey}`}
                         value={tempDate}
                         mode="date"
                         display="default"

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -31,6 +31,7 @@ const statusOptions = [
 export default function ReportFilter({ filters, onFiltersChange, onClearFilters }: ReportFilterProps) {
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState<"start" | "end" | null>(null);
 
   const formatDateForDisplay = (dateString?: string) => {
     if (!dateString) return "選択してください";
@@ -163,24 +164,15 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  DateTimePicker && (
-                    <DateTimePicker
-                      value={filters.startDate ? new Date(filters.startDate) : new Date()}
-                      mode="date"
-                      display="default"
-                      onChange={(event, selectedDate) => {
-                        if (event.type === 'set' && selectedDate) {
-                          const dateString = selectedDate.toISOString().split('T')[0];
-                          onFiltersChange({
-                            ...filters,
-                            startDate: dateString,
-                          });
-                        }
-                        // Calendar automatically closes after selection with 'default' display
-                      }}
-                      style={{ alignSelf: 'flex-start' }}
-                    />
-                  )
+                  <TouchableOpacity
+                    onPress={() => setShowDatePicker("start")}
+                    className="flex-row items-center"
+                  >
+                    <Text className="text-gray-800 flex-1">
+                      {formatDateForDisplay(filters.startDate)}
+                    </Text>
+                    <Ionicons name="calendar-outline" size={16} color="#6B7280" />
+                  </TouchableOpacity>
                 )}
               </View>
               
@@ -218,24 +210,15 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  DateTimePicker && (
-                    <DateTimePicker
-                      value={filters.endDate ? new Date(filters.endDate) : new Date()}
-                      mode="date"
-                      display="default"
-                      onChange={(event, selectedDate) => {
-                        if (event.type === 'set' && selectedDate) {
-                          const dateString = selectedDate.toISOString().split('T')[0];
-                          onFiltersChange({
-                            ...filters,
-                            endDate: dateString,
-                          });
-                        }
-                        // Calendar automatically closes after selection with 'default' display
-                      }}
-                      style={{ alignSelf: 'flex-start' }}
-                    />
-                  )
+                  <TouchableOpacity
+                    onPress={() => setShowDatePicker("end")}
+                    className="flex-row items-center"
+                  >
+                    <Text className="text-gray-800 flex-1">
+                      {formatDateForDisplay(filters.endDate)}
+                    </Text>
+                    <Ionicons name="calendar-outline" size={16} color="#6B7280" />
+                  </TouchableOpacity>
                 )}
               </View>
             </View>
@@ -297,6 +280,34 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
           </View>
         </TouchableOpacity>
       </Modal>
+
+      {/* DateTimePicker for iOS/Android */}
+      {showDatePicker && Platform.OS !== 'web' && DateTimePicker && (
+        <DateTimePicker
+          value={filters[showDatePicker === "start" ? "startDate" : "endDate"] 
+                ? new Date(filters[showDatePicker === "start" ? "startDate" : "endDate"]!) 
+                : new Date()}
+          mode="date"
+          display="default"
+          onChange={(event, selectedDate) => {
+            setShowDatePicker(null);
+            if (event.type === 'set' && selectedDate) {
+              const dateString = selectedDate.toISOString().split('T')[0];
+              if (showDatePicker === "start") {
+                onFiltersChange({
+                  ...filters,
+                  startDate: dateString,
+                });
+              } else if (showDatePicker === "end") {
+                onFiltersChange({
+                  ...filters,
+                  endDate: dateString,
+                });
+              }
+            }
+          }}
+        />
+      )}
     </View>
   );
 }

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -178,10 +178,15 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       });
                     }}
                     onClick={(e: any) => {
-                      e.target.showPicker?.();
-                    }}
-                    onFocus={(e: any) => {
-                      e.target.showPicker?.();
+                      // Only call showPicker on direct user click
+                      try {
+                        if (e.isTrusted) {
+                          e.target.showPicker?.();
+                        }
+                      } catch (error) {
+                        // Fallback: let the browser handle the click naturally
+                        console.log('showPicker not available, using browser default');
+                      }
                     }}
                     style={{
                       width: '100%',
@@ -227,10 +232,15 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       });
                     }}
                     onClick={(e: any) => {
-                      e.target.showPicker?.();
-                    }}
-                    onFocus={(e: any) => {
-                      e.target.showPicker?.();
+                      // Only call showPicker on direct user click
+                      try {
+                        if (e.isTrusted) {
+                          e.target.showPicker?.();
+                        }
+                      } catch (error) {
+                        // Fallback: let the browser handle the click naturally
+                        console.log('showPicker not available, using browser default');
+                      }
                     }}
                     style={{
                       width: '100%',

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -288,79 +288,30 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
         </TouchableOpacity>
       </Modal>
 
-      {/* DateTimePicker Modal for iOS/Android */}
-      {showDatePicker && Platform.OS !== 'web' && (
-        <Modal
-          visible={true}
-          transparent={true}
-          animationType="slide"
-          onRequestClose={() => setShowDatePicker(null)}
-        >
-          <TouchableOpacity 
-            className="flex-1 justify-end bg-black/50"
-            activeOpacity={1}
-            onPress={() => setShowDatePicker(null)}
-          >
-            <TouchableOpacity 
-              className="bg-white"
-              activeOpacity={1}
-              onPress={(e) => e.stopPropagation()}
-            >
-              {/* Header with Cancel/Done buttons */}
-              <View className="flex-row justify-between items-center p-4 border-b border-gray-200">
-                <TouchableOpacity 
-                  onPress={() => setShowDatePicker(null)}
-                  className="py-2"
-                >
-                  <Text className="text-blue-500 text-lg">キャンセル</Text>
-                </TouchableOpacity>
-                <Text className="text-lg font-semibold text-gray-800">
-                  {showDatePicker === "start" ? "開始日を選択" : "終了日を選択"}
-                </Text>
-                <TouchableOpacity 
-                  onPress={() => {
-                    const dateString = tempDate.toISOString().split('T')[0];
-                    if (showDatePicker === "start") {
-                      onFiltersChange({
-                        ...filters,
-                        startDate: dateString,
-                      });
-                    } else if (showDatePicker === "end") {
-                      onFiltersChange({
-                        ...filters,
-                        endDate: dateString,
-                      });
-                    }
-                    setShowDatePicker(null);
-                  }}
-                  className="py-2"
-                >
-                  <Text className="text-blue-500 text-lg font-semibold">完了</Text>
-                </TouchableOpacity>
-              </View>
-              
-              {/* DateTimePicker */}
-              <View className="bg-white" style={{ height: 250 }}>
-                {DateTimePicker && (
-                  <DateTimePicker
-                    value={tempDate}
-                    mode="date"
-                    display="spinner"
-                    onChange={(event, selectedDate) => {
-                      if (selectedDate) {
-                        setTempDate(selectedDate);
-                      }
-                    }}
-                    style={{
-                      backgroundColor: 'white',
-                      height: 250,
-                    }}
-                  />
-                )}
-              </View>
-            </TouchableOpacity>
-          </TouchableOpacity>
-        </Modal>
+      {/* DateTimePicker for iOS/Android */}
+      {showDatePicker && Platform.OS !== 'web' && DateTimePicker && (
+        <DateTimePicker
+          value={tempDate}
+          mode="date"
+          display="default"
+          onChange={(event, selectedDate) => {
+            setShowDatePicker(null);
+            if (event.type === 'set' && selectedDate) {
+              const dateString = selectedDate.toISOString().split('T')[0];
+              if (showDatePicker === "start") {
+                onFiltersChange({
+                  ...filters,
+                  startDate: dateString,
+                });
+              } else if (showDatePicker === "end") {
+                onFiltersChange({
+                  ...filters,
+                  endDate: dateString,
+                });
+              }
+            }
+          }}
+        />
       )}
     </View>
   );

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -32,6 +32,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [showDatePicker, setShowDatePicker] = useState<"start" | "end" | null>(null);
+  const [tempDate, setTempDate] = useState(new Date());
 
   const formatDateForDisplay = (dateString?: string) => {
     if (!dateString) return "選択してください";
@@ -165,7 +166,10 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                   />
                 ) : (
                   <TouchableOpacity
-                    onPress={() => setShowDatePicker("start")}
+                    onPress={() => {
+                      setTempDate(filters.startDate ? new Date(filters.startDate) : new Date());
+                      setShowDatePicker("start");
+                    }}
                     className="flex-row items-center"
                   >
                     <Text className="text-gray-800 flex-1">
@@ -211,7 +215,10 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                   />
                 ) : (
                   <TouchableOpacity
-                    onPress={() => setShowDatePicker("end")}
+                    onPress={() => {
+                      setTempDate(filters.endDate ? new Date(filters.endDate) : new Date());
+                      setShowDatePicker("end");
+                    }}
                     className="flex-row items-center"
                   >
                     <Text className="text-gray-800 flex-1">
@@ -281,32 +288,79 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
         </TouchableOpacity>
       </Modal>
 
-      {/* DateTimePicker for iOS/Android */}
-      {showDatePicker && Platform.OS !== 'web' && DateTimePicker && (
-        <DateTimePicker
-          value={filters[showDatePicker === "start" ? "startDate" : "endDate"] 
-                ? new Date(filters[showDatePicker === "start" ? "startDate" : "endDate"]!) 
-                : new Date()}
-          mode="date"
-          display="default"
-          onChange={(event, selectedDate) => {
-            setShowDatePicker(null);
-            if (event.type === 'set' && selectedDate) {
-              const dateString = selectedDate.toISOString().split('T')[0];
-              if (showDatePicker === "start") {
-                onFiltersChange({
-                  ...filters,
-                  startDate: dateString,
-                });
-              } else if (showDatePicker === "end") {
-                onFiltersChange({
-                  ...filters,
-                  endDate: dateString,
-                });
-              }
-            }
-          }}
-        />
+      {/* DateTimePicker Modal for iOS/Android */}
+      {showDatePicker && Platform.OS !== 'web' && (
+        <Modal
+          visible={true}
+          transparent={true}
+          animationType="slide"
+          onRequestClose={() => setShowDatePicker(null)}
+        >
+          <TouchableOpacity 
+            className="flex-1 justify-end bg-black/50"
+            activeOpacity={1}
+            onPress={() => setShowDatePicker(null)}
+          >
+            <TouchableOpacity 
+              className="bg-white"
+              activeOpacity={1}
+              onPress={(e) => e.stopPropagation()}
+            >
+              {/* Header with Cancel/Done buttons */}
+              <View className="flex-row justify-between items-center p-4 border-b border-gray-200">
+                <TouchableOpacity 
+                  onPress={() => setShowDatePicker(null)}
+                  className="py-2"
+                >
+                  <Text className="text-blue-500 text-lg">キャンセル</Text>
+                </TouchableOpacity>
+                <Text className="text-lg font-semibold text-gray-800">
+                  {showDatePicker === "start" ? "開始日を選択" : "終了日を選択"}
+                </Text>
+                <TouchableOpacity 
+                  onPress={() => {
+                    const dateString = tempDate.toISOString().split('T')[0];
+                    if (showDatePicker === "start") {
+                      onFiltersChange({
+                        ...filters,
+                        startDate: dateString,
+                      });
+                    } else if (showDatePicker === "end") {
+                      onFiltersChange({
+                        ...filters,
+                        endDate: dateString,
+                      });
+                    }
+                    setShowDatePicker(null);
+                  }}
+                  className="py-2"
+                >
+                  <Text className="text-blue-500 text-lg font-semibold">完了</Text>
+                </TouchableOpacity>
+              </View>
+              
+              {/* DateTimePicker */}
+              <View className="bg-white" style={{ height: 250 }}>
+                {DateTimePicker && (
+                  <DateTimePicker
+                    value={tempDate}
+                    mode="date"
+                    display="spinner"
+                    onChange={(event, selectedDate) => {
+                      if (selectedDate) {
+                        setTempDate(selectedDate);
+                      }
+                    }}
+                    style={{
+                      backgroundColor: 'white',
+                      height: 250,
+                    }}
+                  />
+                )}
+              </View>
+            </TouchableOpacity>
+          </TouchableOpacity>
+        </Modal>
       )}
     </View>
   );

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -223,50 +223,63 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
       {showDatePicker && (
         <>
           {Platform.OS === 'web' ? (
-            // Web: HTML input type="date"
+            // Web: HTML input type="date" with calendar
             <Modal
               visible={true}
               transparent={true}
               animationType="fade"
               onRequestClose={cancelDateSelection}
             >
-              <View className="flex-1 justify-center items-center bg-black/50">
-                <View className="bg-white rounded-lg p-6 m-4 min-w-[300px]">
-                  <Text className="text-lg font-semibold text-gray-800 mb-4">
+              <TouchableOpacity 
+                className="flex-1 justify-center items-center bg-black/50"
+                activeOpacity={1}
+                onPress={cancelDateSelection}
+              >
+                <TouchableOpacity 
+                  className="bg-white rounded-lg p-6 m-4 min-w-[320px] max-w-[400px]"
+                  activeOpacity={1}
+                  onPress={(e) => e.stopPropagation()}
+                >
+                  <Text className="text-lg font-semibold text-gray-800 mb-4 text-center">
                     {showDatePicker === "start" ? "開始日を選択" : "終了日を選択"}
                   </Text>
                   
-                  <TextInput
-                    className="border border-gray-300 rounded-lg p-3 mb-4"
-                    // @ts-ignore - Web-only props
-                    type="date"
-                    value={tempDate.toISOString().split('T')[0]}
-                    onChange={(e: any) => {
-                      const date = new Date(e.target.value);
-                      setTempDate(date);
-                    }}
-                    style={{ 
-                      // @ts-ignore - Web-only styles
-                      outlineStyle: 'none',
-                    }}
-                  />
+                  <View className="mb-6">
+                    <input
+                      type="date"
+                      value={tempDate.toISOString().split('T')[0]}
+                      onChange={(e: any) => {
+                        const date = new Date(e.target.value);
+                        setTempDate(date);
+                      }}
+                      style={{
+                        width: '100%',
+                        padding: '12px',
+                        border: '1px solid #d1d5db',
+                        borderRadius: '8px',
+                        fontSize: '16px',
+                        outline: 'none',
+                        boxSizing: 'border-box',
+                      }}
+                    />
+                  </View>
                   
                   <View className="flex-row justify-end space-x-3">
                     <TouchableOpacity 
                       onPress={cancelDateSelection}
                       className="px-4 py-2 bg-gray-200 rounded-lg"
                     >
-                      <Text className="text-gray-700">キャンセル</Text>
+                      <Text className="text-gray-700 font-medium">キャンセル</Text>
                     </TouchableOpacity>
                     <TouchableOpacity 
                       onPress={confirmDateSelection}
                       className="px-4 py-2 bg-blue-500 rounded-lg"
                     >
-                      <Text className="text-white">完了</Text>
+                      <Text className="text-white font-medium">完了</Text>
                     </TouchableOpacity>
                   </View>
-                </View>
-              </View>
+                </TouchableOpacity>
+              </TouchableOpacity>
             </Modal>
           ) : Platform.OS === 'ios' ? (
             <Modal
@@ -275,8 +288,16 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
               animationType="slide"
               onRequestClose={cancelDateSelection}
             >
-              <View className="flex-1 justify-end bg-black/50">
-                <View className="bg-white">
+              <TouchableOpacity 
+                className="flex-1 justify-end bg-black/50"
+                activeOpacity={1}
+                onPress={cancelDateSelection}
+              >
+                <TouchableOpacity 
+                  className="bg-white"
+                  activeOpacity={1}
+                  onPress={(e) => e.stopPropagation()}
+                >
                   {/* iOS Date Picker Header */}
                   <View className="flex-row justify-between items-center p-4 border-b border-gray-200">
                     <TouchableOpacity onPress={cancelDateSelection}>
@@ -291,17 +312,22 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                   </View>
                   
                   {/* iOS Date Picker */}
-                  {DateTimePicker && (
-                    <DateTimePicker
-                      value={tempDate}
-                      mode="date"
-                      display="spinner"
-                      onChange={handleDateChange}
-                      style={{ backgroundColor: 'white' }}
-                    />
-                  )}
-                </View>
-              </View>
+                  <View style={{ height: 200, backgroundColor: 'white' }}>
+                    {DateTimePicker && (
+                      <DateTimePicker
+                        value={tempDate}
+                        mode="date"
+                        display="spinner"
+                        onChange={handleDateChange}
+                        style={{ 
+                          backgroundColor: 'white',
+                          height: 200,
+                        }}
+                      />
+                    )}
+                  </View>
+                </TouchableOpacity>
+              </TouchableOpacity>
             </Modal>
           ) : (
             // Android Date Picker

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react";
 import { View, Text, TouchableOpacity, TextInput, Modal, Platform } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import DateTimePicker from '@react-native-community/datetimepicker';
+
+// Conditional import for DateTimePicker (not available on web)
+let DateTimePicker: any = null;
+if (Platform.OS !== 'web') {
+  DateTimePicker = require('@react-native-community/datetimepicker').default;
+}
 
 export interface FilterOptions {
   startDate?: string;
@@ -217,7 +222,53 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
       {/* Date Picker Modal */}
       {showDatePicker && (
         <>
-          {Platform.OS === 'ios' ? (
+          {Platform.OS === 'web' ? (
+            // Web: HTML input type="date"
+            <Modal
+              visible={true}
+              transparent={true}
+              animationType="fade"
+              onRequestClose={cancelDateSelection}
+            >
+              <View className="flex-1 justify-center items-center bg-black/50">
+                <View className="bg-white rounded-lg p-6 m-4 min-w-[300px]">
+                  <Text className="text-lg font-semibold text-gray-800 mb-4">
+                    {showDatePicker === "start" ? "開始日を選択" : "終了日を選択"}
+                  </Text>
+                  
+                  <TextInput
+                    className="border border-gray-300 rounded-lg p-3 mb-4"
+                    // @ts-ignore - Web-only props
+                    type="date"
+                    value={tempDate.toISOString().split('T')[0]}
+                    onChange={(e: any) => {
+                      const date = new Date(e.target.value);
+                      setTempDate(date);
+                    }}
+                    style={{ 
+                      // @ts-ignore - Web-only styles
+                      outlineStyle: 'none',
+                    }}
+                  />
+                  
+                  <View className="flex-row justify-end space-x-3">
+                    <TouchableOpacity 
+                      onPress={cancelDateSelection}
+                      className="px-4 py-2 bg-gray-200 rounded-lg"
+                    >
+                      <Text className="text-gray-700">キャンセル</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity 
+                      onPress={confirmDateSelection}
+                      className="px-4 py-2 bg-blue-500 rounded-lg"
+                    >
+                      <Text className="text-white">完了</Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              </View>
+            </Modal>
+          ) : Platform.OS === 'ios' ? (
             <Modal
               visible={true}
               transparent={true}
@@ -240,24 +291,28 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                   </View>
                   
                   {/* iOS Date Picker */}
-                  <DateTimePicker
-                    value={tempDate}
-                    mode="date"
-                    display="spinner"
-                    onChange={handleDateChange}
-                    style={{ backgroundColor: 'white' }}
-                  />
+                  {DateTimePicker && (
+                    <DateTimePicker
+                      value={tempDate}
+                      mode="date"
+                      display="spinner"
+                      onChange={handleDateChange}
+                      style={{ backgroundColor: 'white' }}
+                    />
+                  )}
                 </View>
               </View>
             </Modal>
           ) : (
             // Android Date Picker
-            <DateTimePicker
-              value={tempDate}
-              mode="date"
-              display="default"
-              onChange={handleDateChange}
-            />
+            DateTimePicker && (
+              <DateTimePicker
+                value={tempDate}
+                mode="date"
+                display="default"
+                onChange={handleDateChange}
+              />
+            )
           )}
         </>
       )}

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -29,10 +29,8 @@ const statusOptions = [
 ];
 
 export default function ReportFilter({ filters, onFiltersChange, onClearFilters }: ReportFilterProps) {
-  const [showDatePicker, setShowDatePicker] = useState<"start" | "end" | null>(null);
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [tempDate, setTempDate] = useState(new Date());
 
   const formatDateForDisplay = (dateString?: string) => {
     if (!dateString) return "選択してください";
@@ -145,13 +143,11 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       });
                     }}
                     onClick={(e: any) => {
-                      // Only call showPicker on direct user click
                       try {
                         if (e.isTrusted) {
                           e.target.showPicker?.();
                         }
                       } catch (error) {
-                        // Fallback: let the browser handle the click naturally
                         console.log('showPicker not available, using browser default');
                       }
                     }}
@@ -163,24 +159,27 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       color: '#1f2937',
                       backgroundColor: 'transparent',
                       cursor: 'pointer',
-                      appearance: 'none',
-                      WebkitAppearance: 'none',
-                      MozAppearance: 'none',
                     }}
                     placeholder="選択してください"
                   />
                 ) : (
-                  <TouchableOpacity
-                    onPress={() => {
-                      const currentDate = filters.startDate ? new Date(filters.startDate) : new Date();
-                      setTempDate(currentDate);
-                      setShowDatePicker("start");
-                    }}
-                  >
-                    <Text className="text-gray-800">
-                      {formatDateForDisplay(filters.startDate)}
-                    </Text>
-                  </TouchableOpacity>
+                  DateTimePicker && (
+                    <DateTimePicker
+                      value={filters.startDate ? new Date(filters.startDate) : new Date()}
+                      mode="date"
+                      display="compact"
+                      onChange={(event, selectedDate) => {
+                        if (event.type === 'set' && selectedDate) {
+                          const dateString = selectedDate.toISOString().split('T')[0];
+                          onFiltersChange({
+                            ...filters,
+                            startDate: dateString,
+                          });
+                        }
+                      }}
+                      style={{ alignSelf: 'flex-start' }}
+                    />
+                  )
                 )}
               </View>
               
@@ -198,13 +197,11 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       });
                     }}
                     onClick={(e: any) => {
-                      // Only call showPicker on direct user click
                       try {
                         if (e.isTrusted) {
                           e.target.showPicker?.();
                         }
                       } catch (error) {
-                        // Fallback: let the browser handle the click naturally
                         console.log('showPicker not available, using browser default');
                       }
                     }}
@@ -216,24 +213,27 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       color: '#1f2937',
                       backgroundColor: 'transparent',
                       cursor: 'pointer',
-                      appearance: 'none',
-                      WebkitAppearance: 'none',
-                      MozAppearance: 'none',
                     }}
                     placeholder="選択してください"
                   />
                 ) : (
-                  <TouchableOpacity
-                    onPress={() => {
-                      const currentDate = filters.endDate ? new Date(filters.endDate) : new Date();
-                      setTempDate(currentDate);
-                      setShowDatePicker("end");
-                    }}
-                  >
-                    <Text className="text-gray-800">
-                      {formatDateForDisplay(filters.endDate)}
-                    </Text>
-                  </TouchableOpacity>
+                  DateTimePicker && (
+                    <DateTimePicker
+                      value={filters.endDate ? new Date(filters.endDate) : new Date()}
+                      mode="date"
+                      display="compact"
+                      onChange={(event, selectedDate) => {
+                        if (event.type === 'set' && selectedDate) {
+                          const dateString = selectedDate.toISOString().split('T')[0];
+                          onFiltersChange({
+                            ...filters,
+                            endDate: dateString,
+                          });
+                        }
+                      }}
+                      style={{ alignSelf: 'flex-start' }}
+                    />
+                  )
                 )}
               </View>
             </View>
@@ -295,33 +295,6 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
           </View>
         </TouchableOpacity>
       </Modal>
-
-      {/* DateTimePicker - Show when needed (iOS/Android) */}
-      {showDatePicker && Platform.OS !== 'web' && DateTimePicker && (
-        <DateTimePicker
-          value={tempDate}
-          mode="date"
-          display="default"
-          onChange={(event, selectedDate) => {
-            setShowDatePicker(null);
-            if (event.type === 'set' && selectedDate) {
-              const dateString = selectedDate.toISOString().split('T')[0];
-              if (showDatePicker === "start") {
-                onFiltersChange({
-                  ...filters,
-                  startDate: dateString,
-                });
-              } else if (showDatePicker === "end") {
-                onFiltersChange({
-                  ...filters,
-                  endDate: dateString,
-                });
-              }
-            }
-            // If user cancels (event.type === 'dismissed'), do nothing
-          }}
-        />
-      )}
     </View>
   );
 }

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -173,9 +173,8 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                   <>
                     <TouchableOpacity
                       onPress={() => {
-                        if (filters.startDate) {
-                          setTempDate(new Date(filters.startDate));
-                        }
+                        const currentDate = filters.startDate ? new Date(filters.startDate) : new Date();
+                        setTempDate(currentDate);
                         setShowDatePicker("start");
                       }}
                     >
@@ -184,7 +183,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       </Text>
                     </TouchableOpacity>
                     
-                    {/* Hidden DateTimePicker for immediate display */}
+                    {/* DateTimePicker for immediate display */}
                     {showDatePicker === "start" && DateTimePicker && (
                       <DateTimePicker
                         value={tempDate}
@@ -192,13 +191,14 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                         display="default"
                         onChange={(event, selectedDate) => {
                           setShowDatePicker(null);
-                          if (selectedDate) {
+                          if (event.type === 'set' && selectedDate) {
                             const dateString = selectedDate.toISOString().split('T')[0];
                             onFiltersChange({
                               ...filters,
                               startDate: dateString,
                             });
                           }
+                          // If user cancels (event.type === 'dismissed'), do nothing
                         }}
                       />
                     )}
@@ -248,9 +248,8 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                   <>
                     <TouchableOpacity
                       onPress={() => {
-                        if (filters.endDate) {
-                          setTempDate(new Date(filters.endDate));
-                        }
+                        const currentDate = filters.endDate ? new Date(filters.endDate) : new Date();
+                        setTempDate(currentDate);
                         setShowDatePicker("end");
                       }}
                     >
@@ -259,7 +258,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       </Text>
                     </TouchableOpacity>
                     
-                    {/* Hidden DateTimePicker for immediate display */}
+                    {/* DateTimePicker for immediate display */}
                     {showDatePicker === "end" && DateTimePicker && (
                       <DateTimePicker
                         value={tempDate}
@@ -267,13 +266,14 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                         display="default"
                         onChange={(event, selectedDate) => {
                           setShowDatePicker(null);
-                          if (selectedDate) {
+                          if (event.type === 'set' && selectedDate) {
                             const dateString = selectedDate.toISOString().split('T')[0];
                             onFiltersChange({
                               ...filters,
                               endDate: dateString,
                             });
                           }
+                          // If user cancels (event.type === 'dismissed'), do nothing
                         }}
                       />
                     )}

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -325,16 +325,18 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                   </View>
                   
                   {/* iOS Date Picker */}
-                  <View style={{ height: 200, backgroundColor: 'white' }}>
+                  <View style={{ minHeight: 280, backgroundColor: 'white', padding: 20 }}>
                     {DateTimePicker && (
                       <DateTimePicker
                         value={tempDate}
                         mode="date"
-                        display="spinner"
+                        display="compact"
                         onChange={handleDateChange}
+                        textColor="#000000"
+                        accentColor="#2563EB"
                         style={{ 
                           backgroundColor: 'white',
-                          height: 200,
+                          alignSelf: 'center',
                         }}
                       />
                     )}

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -254,12 +254,25 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       }}
                       style={{
                         width: '100%',
-                        padding: '12px',
+                        padding: '12px 16px',
                         border: '1px solid #d1d5db',
                         borderRadius: '8px',
                         fontSize: '16px',
                         outline: 'none',
                         boxSizing: 'border-box',
+                        cursor: 'pointer',
+                        backgroundColor: '#ffffff',
+                        appearance: 'none',
+                        WebkitAppearance: 'none',
+                        MozAppearance: 'none',
+                      }}
+                      onFocus={(e: any) => {
+                        // Ensure the calendar opens when clicking anywhere on the input
+                        e.target.showPicker?.();
+                      }}
+                      onClick={(e: any) => {
+                        // Show picker on click for better UX
+                        e.target.showPicker?.();
                       }}
                     />
                   </View>

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
-import { View, Text, TouchableOpacity, TextInput, Modal, Platform } from "react-native";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  TextInput,
+  Modal,
+} from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-
-// Conditional import for DateTimePicker (not available on web)
-let DateTimePicker: any = null;
-if (Platform.OS !== 'web') {
-  DateTimePicker = require('@react-native-community/datetimepicker').default;
-}
+import DateInput from "./DateInput";
 
 export interface FilterOptions {
   startDate?: string;
@@ -28,13 +29,17 @@ const statusOptions = [
   { value: "APPROVED" as const, label: "承認済み" },
 ];
 
-export default function ReportFilter({ filters, onFiltersChange, onClearFilters }: ReportFilterProps) {
+export default function ReportFilter({
+  filters,
+  onFiltersChange,
+  onClearFilters,
+}: ReportFilterProps) {
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
   const formatDateForDisplay = (dateString?: string) => {
     if (!dateString) return "選択してください";
-    
+
     try {
       const date = new Date(dateString);
       return date.toLocaleDateString("ja-JP", {
@@ -46,7 +51,6 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
       return "選択してください";
     }
   };
-
 
   const handleStatusSelect = (status: FilterOptions["status"]) => {
     onFiltersChange({
@@ -74,7 +78,7 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
   const hasActiveFilters = getActiveFiltersCount() > 0;
 
   const getStatusLabel = (status?: string) => {
-    const option = statusOptions.find(opt => opt.value === status);
+    const option = statusOptions.find((opt) => opt.value === status);
     return option?.label || "すべて";
   };
 
@@ -111,14 +115,16 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
           <Text className="text-gray-700 ml-2 font-medium">フィルター</Text>
           {hasActiveFilters && (
             <View className="bg-blue-500 rounded-full w-5 h-5 items-center justify-center ml-2">
-              <Text className="text-white text-xs font-bold">{getActiveFiltersCount()}</Text>
+              <Text className="text-white text-xs font-bold">
+                {getActiveFiltersCount()}
+              </Text>
             </View>
           )}
         </View>
-        <Ionicons 
-          name={isExpanded ? "chevron-up" : "chevron-down"} 
-          size={20} 
-          color="#6B7280" 
+        <Ionicons
+          name={isExpanded ? "chevron-up" : "chevron-down"}
+          size={20}
+          color="#6B7280"
         />
       </TouchableOpacity>
 
@@ -127,124 +133,50 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
         <View className="px-4 pb-4 bg-gray-50">
           {/* Date Range */}
           <View className="mb-4">
-            <Text className="text-sm font-medium text-gray-700 mb-2">日付範囲</Text>
+            <Text className="text-sm font-medium text-gray-700 mb-2">
+              日付範囲
+            </Text>
             <View className="flex-row space-x-3">
               <View className="flex-1 bg-white border border-gray-200 rounded-lg p-3">
                 <Text className="text-xs text-gray-500 mb-1">開始日</Text>
-                {Platform.OS === 'web' ? (
-                  <input
-                    type="date"
-                    value={filters.startDate || ''}
-                    onChange={(e: any) => {
-                      const dateString = e.target.value;
-                      onFiltersChange({
-                        ...filters,
-                        startDate: dateString || undefined,
-                      });
-                    }}
-                    onClick={(e: any) => {
-                      try {
-                        if (e.isTrusted) {
-                          e.target.showPicker?.();
-                        }
-                      } catch (error) {
-                        console.log('showPicker not available, using browser default');
-                      }
-                    }}
-                    style={{
-                      width: '100%',
-                      border: 'none',
-                      outline: 'none',
-                      fontSize: '16px',
-                      color: '#1f2937',
-                      backgroundColor: 'transparent',
-                      cursor: 'pointer',
-                    }}
-                    placeholder="選択してください"
-                  />
-                ) : (
-                  DateTimePicker && (
-                    <DateTimePicker
-                      value={filters.startDate ? new Date(filters.startDate) : new Date()}
-                      mode="date"
-                      display="compact"
-                      onChange={(event, selectedDate) => {
-                        if (event.type === 'set' && selectedDate) {
-                          const dateString = selectedDate.toISOString().split('T')[0];
-                          onFiltersChange({
-                            ...filters,
-                            startDate: dateString,
-                          });
-                        }
-                      }}
-                    />
-                  )
-                )}
+                <DateInput
+                  value={filters.startDate}
+                  onChange={(dateString) =>
+                    onFiltersChange({
+                      ...filters,
+                      startDate: dateString,
+                    })
+                  }
+                />
               </View>
-              
+
               <View className="flex-1 bg-white border border-gray-200 rounded-lg p-3">
                 <Text className="text-xs text-gray-500 mb-1">終了日</Text>
-                {Platform.OS === 'web' ? (
-                  <input
-                    type="date"
-                    value={filters.endDate || ''}
-                    onChange={(e: any) => {
-                      const dateString = e.target.value;
-                      onFiltersChange({
-                        ...filters,
-                        endDate: dateString || undefined,
-                      });
-                    }}
-                    onClick={(e: any) => {
-                      try {
-                        if (e.isTrusted) {
-                          e.target.showPicker?.();
-                        }
-                      } catch (error) {
-                        console.log('showPicker not available, using browser default');
-                      }
-                    }}
-                    style={{
-                      width: '100%',
-                      border: 'none',
-                      outline: 'none',
-                      fontSize: '16px',
-                      color: '#1f2937',
-                      backgroundColor: 'transparent',
-                      cursor: 'pointer',
-                    }}
-                    placeholder="選択してください"
-                  />
-                ) : (
-                  DateTimePicker && (
-                    <DateTimePicker
-                      value={filters.endDate ? new Date(filters.endDate) : new Date()}
-                      mode="date"
-                      display="compact"
-                      onChange={(event, selectedDate) => {
-                        if (event.type === 'set' && selectedDate) {
-                          const dateString = selectedDate.toISOString().split('T')[0];
-                          onFiltersChange({
-                            ...filters,
-                            endDate: dateString,
-                          });
-                        }
-                      }}
-                    />
-                  )
-                )}
+                <DateInput
+                  value={filters.endDate}
+                  onChange={(dateString) =>
+                    onFiltersChange({
+                      ...filters,
+                      endDate: dateString,
+                    })
+                  }
+                />
               </View>
             </View>
           </View>
 
           {/* Status Filter */}
           <View className="mb-4">
-            <Text className="text-sm font-medium text-gray-700 mb-2">ステータス</Text>
+            <Text className="text-sm font-medium text-gray-700 mb-2">
+              ステータス
+            </Text>
             <TouchableOpacity
               className="bg-white border border-gray-200 rounded-lg p-3"
               onPress={() => setShowStatusModal(true)}
             >
-              <Text className="text-gray-800">{getStatusLabel(filters.status)}</Text>
+              <Text className="text-gray-800">
+                {getStatusLabel(filters.status)}
+              </Text>
             </TouchableOpacity>
           </View>
 
@@ -254,12 +186,13 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
               className="bg-gray-200 rounded-lg p-3 items-center"
               onPress={onClearFilters}
             >
-              <Text className="text-gray-700 font-medium">フィルターをクリア</Text>
+              <Text className="text-gray-700 font-medium">
+                フィルターをクリア
+              </Text>
             </TouchableOpacity>
           )}
         </View>
       )}
-
 
       {/* Status Selection Modal */}
       <Modal
@@ -274,8 +207,10 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
           onPress={() => setShowStatusModal(false)}
         >
           <View className="bg-white rounded-lg m-4 p-4 min-w-[280px]">
-            <Text className="text-lg font-bold text-gray-800 mb-4">ステータスを選択</Text>
-            
+            <Text className="text-lg font-bold text-gray-800 mb-4">
+              ステータスを選択
+            </Text>
+
             {statusOptions.map((option, index) => (
               <TouchableOpacity
                 key={index}
@@ -293,7 +228,6 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
           </View>
         </TouchableOpacity>
       </Modal>
-
     </View>
   );
 }

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -177,6 +177,12 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                         startDate: dateString || undefined,
                       });
                     }}
+                    onClick={(e: any) => {
+                      e.target.showPicker?.();
+                    }}
+                    onFocus={(e: any) => {
+                      e.target.showPicker?.();
+                    }}
                     style={{
                       width: '100%',
                       border: 'none',
@@ -185,6 +191,9 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       color: '#1f2937',
                       backgroundColor: 'transparent',
                       cursor: 'pointer',
+                      appearance: 'none',
+                      WebkitAppearance: 'none',
+                      MozAppearance: 'none',
                     }}
                     placeholder="選択してください"
                   />
@@ -217,6 +226,12 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                         endDate: dateString || undefined,
                       });
                     }}
+                    onClick={(e: any) => {
+                      e.target.showPicker?.();
+                    }}
+                    onFocus={(e: any) => {
+                      e.target.showPicker?.();
+                    }}
                     style={{
                       width: '100%',
                       border: 'none',
@@ -225,6 +240,9 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                       color: '#1f2937',
                       backgroundColor: 'transparent',
                       cursor: 'pointer',
+                      appearance: 'none',
+                      WebkitAppearance: 'none',
+                      MozAppearance: 'none',
                     }}
                     placeholder="選択してください"
                   />

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -49,39 +49,6 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
     }
   };
 
-  const handleDateChange = (event: any, selectedDate?: Date) => {
-    if (Platform.OS === 'android') {
-      setShowDatePicker(null);
-    }
-    
-    if (selectedDate) {
-      setTempDate(selectedDate);
-      
-      // Android: immediately apply the date
-      if (Platform.OS === 'android' && showDatePicker) {
-        const dateString = selectedDate.toISOString().split('T')[0];
-        onFiltersChange({
-          ...filters,
-          [showDatePicker === "start" ? "startDate" : "endDate"]: dateString,
-        });
-      }
-    }
-  };
-
-  const confirmDateSelection = () => {
-    if (showDatePicker) {
-      const dateString = tempDate.toISOString().split('T')[0];
-      onFiltersChange({
-        ...filters,
-        [showDatePicker === "start" ? "startDate" : "endDate"]: dateString,
-      });
-    }
-    setShowDatePicker(null);
-  };
-
-  const cancelDateSelection = () => {
-    setShowDatePicker(null);
-  };
 
   const handleStatusSelect = (status: FilterOptions["status"]) => {
     onFiltersChange({
@@ -203,18 +170,39 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  <TouchableOpacity
-                    onPress={() => {
-                      if (filters.startDate) {
-                        setTempDate(new Date(filters.startDate));
-                      }
-                      setShowDatePicker("start");
-                    }}
-                  >
-                    <Text className="text-gray-800">
-                      {formatDateForDisplay(filters.startDate)}
-                    </Text>
-                  </TouchableOpacity>
+                  <>
+                    <TouchableOpacity
+                      onPress={() => {
+                        if (filters.startDate) {
+                          setTempDate(new Date(filters.startDate));
+                        }
+                        setShowDatePicker("start");
+                      }}
+                    >
+                      <Text className="text-gray-800">
+                        {formatDateForDisplay(filters.startDate)}
+                      </Text>
+                    </TouchableOpacity>
+                    
+                    {/* Hidden DateTimePicker for immediate display */}
+                    {showDatePicker === "start" && DateTimePicker && (
+                      <DateTimePicker
+                        value={tempDate}
+                        mode="date"
+                        display="default"
+                        onChange={(event, selectedDate) => {
+                          setShowDatePicker(null);
+                          if (selectedDate) {
+                            const dateString = selectedDate.toISOString().split('T')[0];
+                            onFiltersChange({
+                              ...filters,
+                              startDate: dateString,
+                            });
+                          }
+                        }}
+                      />
+                    )}
+                  </>
                 )}
               </View>
               
@@ -257,18 +245,39 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  <TouchableOpacity
-                    onPress={() => {
-                      if (filters.endDate) {
-                        setTempDate(new Date(filters.endDate));
-                      }
-                      setShowDatePicker("end");
-                    }}
-                  >
-                    <Text className="text-gray-800">
-                      {formatDateForDisplay(filters.endDate)}
-                    </Text>
-                  </TouchableOpacity>
+                  <>
+                    <TouchableOpacity
+                      onPress={() => {
+                        if (filters.endDate) {
+                          setTempDate(new Date(filters.endDate));
+                        }
+                        setShowDatePicker("end");
+                      }}
+                    >
+                      <Text className="text-gray-800">
+                        {formatDateForDisplay(filters.endDate)}
+                      </Text>
+                    </TouchableOpacity>
+                    
+                    {/* Hidden DateTimePicker for immediate display */}
+                    {showDatePicker === "end" && DateTimePicker && (
+                      <DateTimePicker
+                        value={tempDate}
+                        mode="date"
+                        display="default"
+                        onChange={(event, selectedDate) => {
+                          setShowDatePicker(null);
+                          if (selectedDate) {
+                            const dateString = selectedDate.toISOString().split('T')[0];
+                            onFiltersChange({
+                              ...filters,
+                              endDate: dateString,
+                            });
+                          }
+                        }}
+                      />
+                    )}
+                  </>
                 )}
               </View>
             </View>
@@ -297,72 +306,6 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
         </View>
       )}
 
-      {/* Date Picker Modal - Mobile only */}
-      {showDatePicker && Platform.OS !== 'web' && (
-        <>
-          {Platform.OS === 'ios' ? (
-            <Modal
-              visible={true}
-              transparent={true}
-              animationType="slide"
-              onRequestClose={cancelDateSelection}
-            >
-              <TouchableOpacity 
-                className="flex-1 justify-end bg-black/50"
-                activeOpacity={1}
-                onPress={cancelDateSelection}
-              >
-                <TouchableOpacity 
-                  className="bg-white"
-                  activeOpacity={1}
-                  onPress={(e) => e.stopPropagation()}
-                >
-                  {/* iOS Date Picker Header */}
-                  <View className="flex-row justify-between items-center p-4 border-b border-gray-200">
-                    <TouchableOpacity onPress={cancelDateSelection}>
-                      <Text className="text-blue-500 text-lg">キャンセル</Text>
-                    </TouchableOpacity>
-                    <Text className="text-lg font-semibold text-gray-800">
-                      {showDatePicker === "start" ? "開始日を選択" : "終了日を選択"}
-                    </Text>
-                    <TouchableOpacity onPress={confirmDateSelection}>
-                      <Text className="text-blue-500 text-lg font-semibold">完了</Text>
-                    </TouchableOpacity>
-                  </View>
-                  
-                  {/* iOS Date Picker */}
-                  <View style={{ minHeight: 280, backgroundColor: 'white', padding: 20 }}>
-                    {DateTimePicker && (
-                      <DateTimePicker
-                        value={tempDate}
-                        mode="date"
-                        display="compact"
-                        onChange={handleDateChange}
-                        textColor="#000000"
-                        accentColor="#2563EB"
-                        style={{ 
-                          backgroundColor: 'white',
-                          alignSelf: 'center',
-                        }}
-                      />
-                    )}
-                  </View>
-                </TouchableOpacity>
-              </TouchableOpacity>
-            </Modal>
-          ) : (
-            // Android Date Picker
-            DateTimePicker && (
-              <DateTimePicker
-                value={tempDate}
-                mode="date"
-                display="default"
-                onChange={handleDateChange}
-              />
-            )
-          )}
-        </>
-      )}
 
       {/* Status Selection Modal */}
       <Modal

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -33,9 +33,6 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [tempDate, setTempDate] = useState(new Date());
-  
-  // Force re-render when showDatePicker changes
-  const [pickerKey, setPickerKey] = useState(0);
 
   const formatDateForDisplay = (dateString?: string) => {
     if (!dateString) return "選択してください";
@@ -173,44 +170,17 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  <>
-                    <TouchableOpacity
-                      onPress={() => {
-                        const currentDate = filters.startDate ? new Date(filters.startDate) : new Date();
-                        setTempDate(currentDate);
-                        setPickerKey(prev => prev + 1);
-                        // Use setTimeout to ensure state is updated before showing picker
-                        setTimeout(() => {
-                          setShowDatePicker("start");
-                        }, 0);
-                      }}
-                    >
-                      <Text className="text-gray-800">
-                        {formatDateForDisplay(filters.startDate)}
-                      </Text>
-                    </TouchableOpacity>
-                    
-                    {/* DateTimePicker for immediate display */}
-                    {showDatePicker === "start" && DateTimePicker && (
-                      <DateTimePicker
-                        key={`start-${pickerKey}`}
-                        value={tempDate}
-                        mode="date"
-                        display="default"
-                        onChange={(event, selectedDate) => {
-                          setShowDatePicker(null);
-                          if (event.type === 'set' && selectedDate) {
-                            const dateString = selectedDate.toISOString().split('T')[0];
-                            onFiltersChange({
-                              ...filters,
-                              startDate: dateString,
-                            });
-                          }
-                          // If user cancels (event.type === 'dismissed'), do nothing
-                        }}
-                      />
-                    )}
-                  </>
+                  <TouchableOpacity
+                    onPress={() => {
+                      const currentDate = filters.startDate ? new Date(filters.startDate) : new Date();
+                      setTempDate(currentDate);
+                      setShowDatePicker("start");
+                    }}
+                  >
+                    <Text className="text-gray-800">
+                      {formatDateForDisplay(filters.startDate)}
+                    </Text>
+                  </TouchableOpacity>
                 )}
               </View>
               
@@ -253,44 +223,17 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
                     placeholder="選択してください"
                   />
                 ) : (
-                  <>
-                    <TouchableOpacity
-                      onPress={() => {
-                        const currentDate = filters.endDate ? new Date(filters.endDate) : new Date();
-                        setTempDate(currentDate);
-                        setPickerKey(prev => prev + 1);
-                        // Use setTimeout to ensure state is updated before showing picker
-                        setTimeout(() => {
-                          setShowDatePicker("end");
-                        }, 0);
-                      }}
-                    >
-                      <Text className="text-gray-800">
-                        {formatDateForDisplay(filters.endDate)}
-                      </Text>
-                    </TouchableOpacity>
-                    
-                    {/* DateTimePicker for immediate display */}
-                    {showDatePicker === "end" && DateTimePicker && (
-                      <DateTimePicker
-                        key={`end-${pickerKey}`}
-                        value={tempDate}
-                        mode="date"
-                        display="default"
-                        onChange={(event, selectedDate) => {
-                          setShowDatePicker(null);
-                          if (event.type === 'set' && selectedDate) {
-                            const dateString = selectedDate.toISOString().split('T')[0];
-                            onFiltersChange({
-                              ...filters,
-                              endDate: dateString,
-                            });
-                          }
-                          // If user cancels (event.type === 'dismissed'), do nothing
-                        }}
-                      />
-                    )}
-                  </>
+                  <TouchableOpacity
+                    onPress={() => {
+                      const currentDate = filters.endDate ? new Date(filters.endDate) : new Date();
+                      setTempDate(currentDate);
+                      setShowDatePicker("end");
+                    }}
+                  >
+                    <Text className="text-gray-800">
+                      {formatDateForDisplay(filters.endDate)}
+                    </Text>
+                  </TouchableOpacity>
                 )}
               </View>
             </View>
@@ -352,6 +295,33 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
           </View>
         </TouchableOpacity>
       </Modal>
+
+      {/* DateTimePicker - Show when needed (iOS/Android) */}
+      {showDatePicker && Platform.OS !== 'web' && DateTimePicker && (
+        <DateTimePicker
+          value={tempDate}
+          mode="date"
+          display="default"
+          onChange={(event, selectedDate) => {
+            setShowDatePicker(null);
+            if (event.type === 'set' && selectedDate) {
+              const dateString = selectedDate.toISOString().split('T')[0];
+              if (showDatePicker === "start") {
+                onFiltersChange({
+                  ...filters,
+                  startDate: dateString,
+                });
+              } else if (showDatePicker === "end") {
+                onFiltersChange({
+                  ...filters,
+                  endDate: dateString,
+                });
+              }
+            }
+            // If user cancels (event.type === 'dismissed'), do nothing
+          }}
+        />
+      )}
     </View>
   );
 }

--- a/frontend/src/features/reports/components/ReportFilter.tsx
+++ b/frontend/src/features/reports/components/ReportFilter.tsx
@@ -164,35 +164,85 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
           <View className="mb-4">
             <Text className="text-sm font-medium text-gray-700 mb-2">日付範囲</Text>
             <View className="flex-row space-x-3">
-              <TouchableOpacity
-                className="flex-1 bg-white border border-gray-200 rounded-lg p-3"
-                onPress={() => {
-                  if (filters.startDate) {
-                    setTempDate(new Date(filters.startDate));
-                  }
-                  setShowDatePicker("start");
-                }}
-              >
+              <View className="flex-1 bg-white border border-gray-200 rounded-lg p-3">
                 <Text className="text-xs text-gray-500 mb-1">開始日</Text>
-                <Text className="text-gray-800">
-                  {formatDateForDisplay(filters.startDate)}
-                </Text>
-              </TouchableOpacity>
+                {Platform.OS === 'web' ? (
+                  <input
+                    type="date"
+                    value={filters.startDate || ''}
+                    onChange={(e: any) => {
+                      const dateString = e.target.value;
+                      onFiltersChange({
+                        ...filters,
+                        startDate: dateString || undefined,
+                      });
+                    }}
+                    style={{
+                      width: '100%',
+                      border: 'none',
+                      outline: 'none',
+                      fontSize: '16px',
+                      color: '#1f2937',
+                      backgroundColor: 'transparent',
+                      cursor: 'pointer',
+                    }}
+                    placeholder="選択してください"
+                  />
+                ) : (
+                  <TouchableOpacity
+                    onPress={() => {
+                      if (filters.startDate) {
+                        setTempDate(new Date(filters.startDate));
+                      }
+                      setShowDatePicker("start");
+                    }}
+                  >
+                    <Text className="text-gray-800">
+                      {formatDateForDisplay(filters.startDate)}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
               
-              <TouchableOpacity
-                className="flex-1 bg-white border border-gray-200 rounded-lg p-3"
-                onPress={() => {
-                  if (filters.endDate) {
-                    setTempDate(new Date(filters.endDate));
-                  }
-                  setShowDatePicker("end");
-                }}
-              >
+              <View className="flex-1 bg-white border border-gray-200 rounded-lg p-3">
                 <Text className="text-xs text-gray-500 mb-1">終了日</Text>
-                <Text className="text-gray-800">
-                  {formatDateForDisplay(filters.endDate)}
-                </Text>
-              </TouchableOpacity>
+                {Platform.OS === 'web' ? (
+                  <input
+                    type="date"
+                    value={filters.endDate || ''}
+                    onChange={(e: any) => {
+                      const dateString = e.target.value;
+                      onFiltersChange({
+                        ...filters,
+                        endDate: dateString || undefined,
+                      });
+                    }}
+                    style={{
+                      width: '100%',
+                      border: 'none',
+                      outline: 'none',
+                      fontSize: '16px',
+                      color: '#1f2937',
+                      backgroundColor: 'transparent',
+                      cursor: 'pointer',
+                    }}
+                    placeholder="選択してください"
+                  />
+                ) : (
+                  <TouchableOpacity
+                    onPress={() => {
+                      if (filters.endDate) {
+                        setTempDate(new Date(filters.endDate));
+                      }
+                      setShowDatePicker("end");
+                    }}
+                  >
+                    <Text className="text-gray-800">
+                      {formatDateForDisplay(filters.endDate)}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
             </View>
           </View>
 
@@ -219,82 +269,10 @@ export default function ReportFilter({ filters, onFiltersChange, onClearFilters 
         </View>
       )}
 
-      {/* Date Picker Modal */}
-      {showDatePicker && (
+      {/* Date Picker Modal - Mobile only */}
+      {showDatePicker && Platform.OS !== 'web' && (
         <>
-          {Platform.OS === 'web' ? (
-            // Web: HTML input type="date" with calendar
-            <Modal
-              visible={true}
-              transparent={true}
-              animationType="fade"
-              onRequestClose={cancelDateSelection}
-            >
-              <TouchableOpacity 
-                className="flex-1 justify-center items-center bg-black/50"
-                activeOpacity={1}
-                onPress={cancelDateSelection}
-              >
-                <TouchableOpacity 
-                  className="bg-white rounded-lg p-6 m-4 min-w-[320px] max-w-[400px]"
-                  activeOpacity={1}
-                  onPress={(e) => e.stopPropagation()}
-                >
-                  <Text className="text-lg font-semibold text-gray-800 mb-4 text-center">
-                    {showDatePicker === "start" ? "開始日を選択" : "終了日を選択"}
-                  </Text>
-                  
-                  <View className="mb-6">
-                    <input
-                      type="date"
-                      value={tempDate.toISOString().split('T')[0]}
-                      onChange={(e: any) => {
-                        const date = new Date(e.target.value);
-                        setTempDate(date);
-                      }}
-                      style={{
-                        width: '100%',
-                        padding: '12px 16px',
-                        border: '1px solid #d1d5db',
-                        borderRadius: '8px',
-                        fontSize: '16px',
-                        outline: 'none',
-                        boxSizing: 'border-box',
-                        cursor: 'pointer',
-                        backgroundColor: '#ffffff',
-                        appearance: 'none',
-                        WebkitAppearance: 'none',
-                        MozAppearance: 'none',
-                      }}
-                      onFocus={(e: any) => {
-                        // Ensure the calendar opens when clicking anywhere on the input
-                        e.target.showPicker?.();
-                      }}
-                      onClick={(e: any) => {
-                        // Show picker on click for better UX
-                        e.target.showPicker?.();
-                      }}
-                    />
-                  </View>
-                  
-                  <View className="flex-row justify-end space-x-3">
-                    <TouchableOpacity 
-                      onPress={cancelDateSelection}
-                      className="px-4 py-2 bg-gray-200 rounded-lg"
-                    >
-                      <Text className="text-gray-700 font-medium">キャンセル</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity 
-                      onPress={confirmDateSelection}
-                      className="px-4 py-2 bg-blue-500 rounded-lg"
-                    >
-                      <Text className="text-white font-medium">完了</Text>
-                    </TouchableOpacity>
-                  </View>
-                </TouchableOpacity>
-              </TouchableOpacity>
-            </Modal>
-          ) : Platform.OS === 'ios' ? (
+          {Platform.OS === 'ios' ? (
             <Modal
               visible={true}
               transparent={true}


### PR DESCRIPTION
## PR に関連する issue

Close #16

## やったこと

- DateInputコンポーネントを新規作成し、日付選択ロジックを共通化
- ReportFilterコンポーネント内の重複していた開始日・終了日の実装を統一
- Web（input[type="date"]）とネイティブ（DateTimePicker）の実装を1つのコンポーネントに統合
- インラインスタイルをTailwindCSSクラスに変更
- DateTimePicker にkey propとthemeVariant設定を追加

## レビュー情報

このPR内で特にレビューしてほしいところ：
- DateInputコンポーネントのプロップス設計（valueとonChangeのインターフェース）
- WebとネイティブプラットフォームでのDatePicker実装の統一アプローチ
- TailwindCSSクラスへの変換が適切か

## 実装の思考プロセス

なぜこのアプローチを選択したか：
- ReportFilterコンポーネント内で開始日と終了日の実装が重複していたため、保守性向上のために共通化
- WebとネイティブでのDatePicker実装をPlatform.OSで分岐させることで、プラットフォーム固有の最適化を維持
- プロップスとしてvalueとonChangeのみを受け取るシンプルな設計にすることで、再利用性を確保

実装時に考慮した点：
- onChange関数でstring | undefinedを受け取れるように設計し、日付クリア機能に対応
- ネイティブ側でkey propを追加してvalue変更時の再レンダリングを確実に
- themeVariant="light"で一貫したスタイリング

## テスト手順

1. バックエンドビルド・起動:
   ```bash
   cd backend && ./gradlew build && ./gradlew bootRun
   ```

2. API確認:
   - http://localhost:8080/swagger-ui.html

3. フロントエンド確認:
   ```bash
   cd frontend && npm run start
   ```

4. 日報一覧画面でフィルター機能を確認:
   - 開始日・終了日の選択が正常に動作することを確認
   - Web・ネイティブアプリの両方で日付選択が動作することを確認

## 影響範囲

- `frontend/src/features/reports/components/ReportFilter.tsx`: 日付入力部分を新しいDateInputコンポーネントに置き換え
- `frontend/src/features/reports/components/DateInput.tsx`: 新規作成
- 既存の日付フィルター機能に影響なし
- データベース変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)