### PR TITLE
remove: バックエンドからlogger使用を全削除

### DIFF
--- a/backend/src/main/java/com/example/backend/application/usecases/external/github/GitHubUseCase.java
+++ b/backend/src/main/java/com/example/backend/application/usecases/external/github/GitHubUseCase.java
@@ -6,7 +6,6 @@ import com.example.backend.domain.external.github.GitHubCommit;
 import com.example.backend.domain.external.github.PullRequest;
 import com.example.backend.domain.external.github.IGitHubRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -19,7 +18,6 @@ import java.util.stream.Collectors;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class GitHubUseCase {
     
     private final IGitHubRepository IGitHubRepository;
@@ -32,7 +30,6 @@ public class GitHubUseCase {
      * @return 接続成功時true
      */
     public boolean testConnection(String owner, String repo) {
-        log.info("Testing GitHub connection for {}/{}", owner, repo);
         return IGitHubRepository.testConnection(owner, repo);
     }
     
@@ -45,7 +42,6 @@ public class GitHubUseCase {
      * @return プルリクエストDTO一覧
      */
     public List<PullRequestDto> getPullRequestsForDate(String owner, String repo, LocalDate date) {
-        log.info("Fetching pull requests for {}/{} on {}", owner, repo, date);
         
         List<PullRequest> pullRequests = IGitHubRepository.findPullRequestsByDate(owner, repo, date);
         
@@ -63,7 +59,6 @@ public class GitHubUseCase {
      * @return コミットDTO一覧
      */
     public List<CommitDto> getCommitsForDate(String owner, String repo, LocalDate date) {
-        log.info("Fetching commits for {}/{} on {}", owner, repo, date);
         
         List<GitHubCommit> commits = IGitHubRepository.findCommitsByDate(owner, repo, date);
         

--- a/backend/src/main/java/com/example/backend/application/usecases/external/notion/NotionUseCase.java
+++ b/backend/src/main/java/com/example/backend/application/usecases/external/notion/NotionUseCase.java
@@ -6,7 +6,6 @@ import com.example.backend.domain.external.notion.NotionPage;
 import com.example.backend.domain.external.notion.NotionTableRow;
 import com.example.backend.domain.external.notion.INotionRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,7 +17,6 @@ import java.util.stream.Collectors;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class NotionUseCase {
     
     private final INotionRepository notionRepository;
@@ -29,7 +27,6 @@ public class NotionUseCase {
      * @return 接続成功時true
      */
     public boolean testConnection() {
-        log.info("Testing Notion connection");
         return notionRepository.testConnection();
     }
     
@@ -39,7 +36,6 @@ public class NotionUseCase {
      * @return ページ情報DTO
      */
     public NotionPageDto getPageContent() {
-        log.info("Fetching Notion page content");
         
         NotionPage page = notionRepository.getPageContent();
         return toNotionPageDto(page);
@@ -51,7 +47,6 @@ public class NotionUseCase {
      * @return テーブル行データDTOのリスト
      */
     public List<NotionTableRowDto> getTableContent() {
-        log.info("Fetching Notion table content");
         
         List<NotionTableRow> rows = notionRepository.getTableContent();
         

--- a/backend/src/main/java/com/example/backend/application/usecases/external/toggle/ToggleTrackUseCase.java
+++ b/backend/src/main/java/com/example/backend/application/usecases/external/toggle/ToggleTrackUseCase.java
@@ -4,7 +4,6 @@ import com.example.backend.application.dto.external.toggle.TimeEntryDto;
 import com.example.backend.domain.external.toggle.TimeEntry;
 import com.example.backend.domain.external.toggle.IToggleTrackRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,7 +15,6 @@ import java.util.stream.Collectors;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class ToggleTrackUseCase {
     
     private final IToggleTrackRepository toggleTrackRepository;
@@ -27,7 +25,6 @@ public class ToggleTrackUseCase {
      * @return 接続成功時true
      */
     public boolean testConnection() {
-        log.info("Testing ToggleTrack connection");
         return toggleTrackRepository.testConnection();
     }
     
@@ -37,7 +34,6 @@ public class ToggleTrackUseCase {
      * @return 今日の時間記録DTOのリスト
      */
     public List<TimeEntryDto> getTodayTimeEntries() {
-        log.info("Fetching today's ToggleTrack time entries");
         
         List<TimeEntry> timeEntries = toggleTrackRepository.getTodayTimeEntries();
         

--- a/backend/src/main/java/com/example/backend/application/usecases/reports/ReportGenerationUseCase.java
+++ b/backend/src/main/java/com/example/backend/application/usecases/reports/ReportGenerationUseCase.java
@@ -11,7 +11,6 @@ import com.example.backend.application.usecases.external.notion.NotionUseCase;
 import com.example.backend.application.usecases.external.toggle.ToggleTrackUseCase;
 import com.example.backend.domain.reports.IReportGenerationService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +24,6 @@ import java.util.UUID;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class ReportGenerationUseCase {
     
     private final IReportGenerationService reportGenerationService;
@@ -43,7 +41,6 @@ public class ReportGenerationUseCase {
     @Transactional
     public ReportGenerationResponseDto generateReport(ReportGenerationRequestDto request) {
         try {
-            log.info("日報生成開始 - ユーザーID: {}, 対象日: {}", request.getUserId(), request.getReportDate());
             
             if (!request.isValid()) {
                 return ReportGenerationResponseDto.failure(
@@ -92,7 +89,6 @@ public class ReportGenerationUseCase {
                 
             DailyReportDto createdReport = reportUseCase.createReport(createRequest);
             
-            log.info("日報生成完了 - 日報ID: {}", createdReport.getId());
             
             return ReportGenerationResponseDto.success(
                 createdReport.getId(),
@@ -103,8 +99,6 @@ public class ReportGenerationUseCase {
             );
             
         } catch (Exception e) {
-            log.error("日報生成エラー - ユーザーID: {}, 対象日: {}", 
-                request.getUserId(), request.getReportDate(), e);
             
             return ReportGenerationResponseDto.failure(
                 request.getUserId(),
@@ -123,7 +117,6 @@ public class ReportGenerationUseCase {
     @Transactional
     public ReportGenerationResponseDto regenerateReport(ReportRegenerationRequestDto request) {
         try {
-            log.info("日報再生成開始 - 日報ID: {}", request.getReportId());
             
             if (!request.isValid()) {
                 return ReportGenerationResponseDto.failure(
@@ -168,7 +161,6 @@ public class ReportGenerationUseCase {
                 
             DailyReportDto updatedReport = reportUseCase.updateReport(request.getReportId(), updateRequest);
             
-            log.info("日報再生成完了 - 日報ID: {}", updatedReport.getId());
             
             return ReportGenerationResponseDto.success(
                 updatedReport.getId(),
@@ -179,7 +171,6 @@ public class ReportGenerationUseCase {
             );
             
         } catch (Exception e) {
-            log.error("日報再生成エラー - 日報ID: {}", request.getReportId(), e);
             
             return ReportGenerationResponseDto.failure(
                 null, null,
@@ -197,7 +188,6 @@ public class ReportGenerationUseCase {
             //現在は空データを返す
             return "{}";
         } catch (Exception e) {
-            log.warn("GitHubデータ取得エラー - ユーザーID: {}, 日付: {}", userId, date, e);
             return "{}";
         }
     }
@@ -211,7 +201,6 @@ public class ReportGenerationUseCase {
             // 現在は空データを返す
             return "{}";
         } catch (Exception e) {
-            log.warn("Togglデータ取得エラー - ユーザーID: {}, 日付: {}", userId, date, e);
             return "{}";
         }
     }
@@ -225,7 +214,6 @@ public class ReportGenerationUseCase {
             // 現在は空データを返す
             return "{}";
         } catch (Exception e) {
-            log.warn("Notionデータ取得エラー - ユーザーID: {}, 日付: {}", userId, date, e);
             return "{}";
         }
     }

--- a/backend/src/main/java/com/example/backend/common/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/backend/common/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.example.backend.common.exceptions;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,12 +11,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestControllerAdvice
-@Slf4j
 public class GlobalExceptionHandler {
     
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<Map<String, Object>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
-        log.error("Parameter type mismatch: {}", e.getMessage());
         
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("error", "INVALID_PARAMETER_TYPE");
@@ -30,7 +27,6 @@ public class GlobalExceptionHandler {
     
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleGenericException(Exception e) {
-        log.error("Unexpected error: {}", e.getMessage(), e);
         
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("error", "INTERNAL_SERVER_ERROR");

--- a/backend/src/main/java/com/example/backend/infrastructure/repositories/external/github/GitHubRepository.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/repositories/external/github/GitHubRepository.java
@@ -3,7 +3,6 @@ package com.example.backend.infrastructure.repositories.external.github;
 import com.example.backend.domain.external.github.GitHubCommit;
 import com.example.backend.domain.external.github.PullRequest;
 import com.example.backend.domain.external.github.IGitHubRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -15,26 +14,22 @@ import java.util.List;
  * 将来的にGitHub API連携を実装する際の基盤クラス
  */
 @Repository
-@Slf4j
 public class GitHubRepository implements IGitHubRepository {
 
     @Override
     public boolean testConnection(String owner, String repo) {
-        log.info("Testing connection to {}/{}", owner, repo);
         // TODO: 実際のGitHub API接続テストを実装
         return true;
     }
 
     @Override
     public List<PullRequest> findPullRequestsByDate(String owner, String repo, LocalDate date) {
-        log.info("Finding pull requests for {}/{} on {}", owner, repo, date);
         // TODO: 実際のGitHub API呼び出しを実装
         return Collections.emptyList();
     }
 
     @Override
     public List<GitHubCommit> findCommitsByDate(String owner, String repo, LocalDate date) {
-        log.info("Finding commits for {}/{} on {}", owner, repo, date);
         // TODO: 実際のGitHub API呼び出しを実装
         return Collections.emptyList();
     }

--- a/backend/src/main/java/com/example/backend/infrastructure/repositories/external/notion/NotionRepository.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/repositories/external/notion/NotionRepository.java
@@ -3,7 +3,6 @@ package com.example.backend.infrastructure.repositories.external.notion;
 import com.example.backend.domain.external.notion.NotionPage;
 import com.example.backend.domain.external.notion.NotionTableRow;
 import com.example.backend.domain.external.notion.INotionRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -15,19 +14,16 @@ import java.util.Map;
  * 将来的にNotion API連携を実装する際の基盤クラス
  */
 @Repository
-@Slf4j
 public class NotionRepository implements INotionRepository {
 
     @Override
     public boolean testConnection() {
-        log.info("Testing connection to Notion");
         // TODO: 実際のNotion API接続テストを実装
         return true;
     }
 
     @Override
     public NotionPage getPageContent() {
-        log.info("Fetching Notion page content");
         // TODO: 実際のNotion API呼び出しを実装
         // 設定済みページIDを使用してAPIコールする
         
@@ -45,7 +41,6 @@ public class NotionRepository implements INotionRepository {
 
     @Override
     public List<NotionTableRow> getTableContent() {
-        log.info("Fetching Notion table content");
         // TODO: 実際のNotion API呼び出しを実装
         // 設定済みテーブルIDを使用してAPIコールする
         

--- a/backend/src/main/java/com/example/backend/infrastructure/repositories/external/toggle/ToggleTrackRepository.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/repositories/external/toggle/ToggleTrackRepository.java
@@ -2,7 +2,6 @@ package com.example.backend.infrastructure.repositories.external.toggle;
 
 import com.example.backend.domain.external.toggle.TimeEntry;
 import com.example.backend.domain.external.toggle.IToggleTrackRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -13,19 +12,16 @@ import java.util.List;
  * 将来的にToggleTrack API連携を実装する際の基盤クラス
  */
 @Repository
-@Slf4j
 public class ToggleTrackRepository implements IToggleTrackRepository {
 
     @Override
     public boolean testConnection() {
-        log.info("Testing connection to ToggleTrack");
         // TODO: 実際のToggleTrack API接続テストを実装
         return true;
     }
 
     @Override
     public List<TimeEntry> getTodayTimeEntries() {
-        log.info("Fetching today's ToggleTrack time entries");
         // TODO: 実際のToggleTrack API呼び出しを実装
         // 今日の日付を使用してAPIコールする
         

--- a/backend/src/main/java/com/example/backend/infrastructure/repositories/reports/DailyReportRepository.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/repositories/reports/DailyReportRepository.java
@@ -7,7 +7,6 @@ import com.example.backend.domain.reports.ReportStatus;
 import com.example.backend.domain.reports.IDailyReportRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
 import org.springframework.stereotype.Repository;
 
@@ -25,14 +24,12 @@ import org.jooq.JSONB;
  */
 @Repository
 @RequiredArgsConstructor
-@Slf4j
 public class DailyReportRepository implements IDailyReportRepository {
     
     private final DSLContext dsl;
 
     @Override
     public DailyReport save(DailyReport report) {
-        log.info("Saving daily report: {}", report.getId());
         
         if (existsById(report.getId())) {
             return update(report);
@@ -43,7 +40,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public Optional<DailyReport> findById(UUID id) {
-        log.debug("Finding daily report by id: {}", id);
         
         return dsl.selectFrom(DAILY_REPORTS)
                 .where(DAILY_REPORTS.ID.eq(id))
@@ -53,7 +49,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public Optional<DailyReport> findByUserIdAndDate(UUID userId, LocalDate reportDate) {
-        log.debug("Finding daily report by userId: {} and date: {}", userId, reportDate);
         
         return dsl.selectFrom(DAILY_REPORTS)
                 .where(DAILY_REPORTS.USER_ID.eq(userId)
@@ -64,7 +59,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public List<DailyReport> findByUserId(UUID userId) {
-        log.debug("Finding daily reports by userId: {}", userId);
         
         return dsl.selectFrom(DAILY_REPORTS)
                 .where(DAILY_REPORTS.USER_ID.eq(userId))
@@ -75,7 +69,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public List<DailyReport> findByUserIdAndDateRange(UUID userId, LocalDate startDate, LocalDate endDate) {
-        log.debug("Finding daily reports by userId: {} and date range: {} to {}", userId, startDate, endDate);
         
         return dsl.selectFrom(DAILY_REPORTS)
                 .where(DAILY_REPORTS.USER_ID.eq(userId)
@@ -87,7 +80,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public List<DailyReport> findByUserIdAndStatus(UUID userId, ReportStatus status) {
-        log.debug("Finding daily reports by userId: {} and status: {}", userId, status);
         
         return dsl.selectFrom(DAILY_REPORTS)
                 .where(DAILY_REPORTS.USER_ID.eq(userId)
@@ -99,7 +91,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public List<DailyReport> findByUserIdAndDateRangeAndStatus(UUID userId, LocalDate startDate, LocalDate endDate, ReportStatus status) {
-        log.debug("Finding daily reports by userId: {}, date range: {} to {}, and status: {}", userId, startDate, endDate, status);
         
         return dsl.selectFrom(DAILY_REPORTS)
                 .where(DAILY_REPORTS.USER_ID.eq(userId)
@@ -112,7 +103,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public boolean deleteById(UUID id) {
-        log.info("Deleting daily report by id: {}", id);
         
         int deletedCount = dsl.deleteFrom(DAILY_REPORTS)
                 .where(DAILY_REPORTS.ID.eq(id))
@@ -123,7 +113,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public boolean existsById(UUID id) {
-        log.debug("Checking existence of daily report by id: {}", id);
         
         return dsl.selectCount()
                 .from(DAILY_REPORTS)
@@ -133,7 +122,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public boolean existsByUserIdAndDate(UUID userId, LocalDate reportDate) {
-        log.debug("Checking existence of daily report by userId: {} and date: {}", userId, reportDate);
         
         return dsl.selectCount()
                 .from(DAILY_REPORTS)
@@ -144,7 +132,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public long countByUserId(UUID userId) {
-        log.debug("Counting daily reports by userId: {}", userId);
         
         return dsl.selectCount()
                 .from(DAILY_REPORTS)
@@ -154,7 +141,6 @@ public class DailyReportRepository implements IDailyReportRepository {
     
     @Override
     public long countByUserIdAndStatus(UUID userId, ReportStatus status) {
-        log.debug("Counting daily reports by userId: {} and status: {}", userId, status);
         
         return dsl.selectCount()
                 .from(DAILY_REPORTS)
@@ -170,7 +156,6 @@ public class DailyReportRepository implements IDailyReportRepository {
      * @return 挿入された日報エンティティ
      */
     private DailyReport insert(DailyReport report) {
-        log.debug("Inserting new daily report: {}", report.getId());
         
         dsl.insertInto(DAILY_REPORTS)
                 .set(DAILY_REPORTS.ID, report.getId())
@@ -197,7 +182,6 @@ public class DailyReportRepository implements IDailyReportRepository {
      * @return 更新された日報エンティティ
      */
     private DailyReport update(DailyReport report) {
-        log.debug("Updating existing daily report: {}", report.getId());
         
         dsl.update(DAILY_REPORTS)
                 .set(DAILY_REPORTS.RAW_DATA, report.getRawData() != null ? JSONB.valueOf(report.getRawData()) : null)

--- a/backend/src/main/java/com/example/backend/infrastructure/repositories/reports/OpenAiIReportGenerationService.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/repositories/reports/OpenAiIReportGenerationService.java
@@ -1,7 +1,6 @@
 package com.example.backend.infrastructure.repositories.reports;
 
 import com.example.backend.domain.reports.IReportGenerationService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +13,6 @@ import java.util.UUID;
  * Spring AI ChatClientを使用してAI日報生成を実装
  */
 @Service
-@Slf4j
 public class OpenAiIReportGenerationService implements IReportGenerationService {
     
     private final ChatClient chatClient;
@@ -50,7 +48,6 @@ public class OpenAiIReportGenerationService implements IReportGenerationService 
         String additionalNotes
     ) {
         try {
-            log.info("AI日報生成開始 - ユーザーID: {}, 日付: {}", userId, reportDate);
             
             String userPrompt = buildGenerationPrompt(
                 reportDate, githubData, togglData, notionData, additionalNotes
@@ -58,11 +55,9 @@ public class OpenAiIReportGenerationService implements IReportGenerationService 
             
             String generatedContent = callOpenAI(userPrompt);
             
-            log.info("AI日報生成完了 - ユーザーID: {}", userId);
             return generatedContent;
             
         } catch (Exception e) {
-            log.error("AI日報生成エラー - ユーザーID: {}", userId, e);
             throw new RuntimeException("AI日報生成に失敗しました", e);
         }
     }
@@ -79,7 +74,6 @@ public class OpenAiIReportGenerationService implements IReportGenerationService 
         String additionalNotes
     ) {
         try {
-            log.info("AI日報再生成開始 - ユーザーID: {}, 日付: {}", userId, reportDate);
             
             String userPrompt = buildRegenerationPrompt(
                 reportDate, githubData, togglData, notionData, 
@@ -88,11 +82,9 @@ public class OpenAiIReportGenerationService implements IReportGenerationService 
             
             String regeneratedContent = callOpenAI(userPrompt);
             
-            log.info("AI日報再生成完了 - ユーザーID: {}", userId);
             return regeneratedContent;
             
         } catch (Exception e) {
-            log.error("AI日報再生成エラー - ユーザーID: {}", userId, e);
             throw new RuntimeException("AI日報再生成に失敗しました", e);
         }
     }


### PR DESCRIPTION
## PR に関連する issue

特定のissueはありませんが、バックエンドコードの簡素化・保守性向上のための改善作業です。

## やったこと

- バックエンド全体からSLF4J loggerの使用を完全削除
- 10個のJavaファイルから@Slf4jアノテーションを削除
- lombok.extern.slf4j.Slf4jのimportを全て削除
- log.info(), log.error(), log.warn(), log.debug()呼び出しを全て削除
- logger削除に伴うコンパイルエラーを修正
- バックエンドのコンパイル・ビルドが正常に動作することを確認

## レビュー情報

**特にレビューしてほしいところ：**
- logger削除によるエラーハンドリングへの影響がないか
- 削除されたログ情報で開発・デバッグに支障がないか
- 削除漏れやコンパイルエラーがないか確認

**レビューの参考情報：**
- 削除対象：10ファイル、68行削除
- 影響範囲：ユースケース層、リポジトリ層、例外ハンドリング
- 機能的な変更なし（ログ出力のみ削除）

## 実装の思考プロセス

**なぜloggerを削除するのか：**
- 現在のlogger使用は主に処理開始/完了の記録とデバッグ情報
- 本格運用前の開発段階では過度な詳細ログは不要
- コードの可読性向上とインフラ簡素化
- プロダクション環境での不要なログ出力削減

**アプローチの選択理由：**
- 段階的削除：import → アノテーション → メソッド呼び出しの順
- 一括処理：sedコマンドによる効率的な削除
- コンパイル確認：各段階でビルド成功を確認

**考慮した点：**
- エラーハンドリングロジックは保持
- try-catch構造は維持
- 外部API統合の動作は変更なし
- データベース操作の動作は変更なし

**将来への配慮：**
- 必要に応じて将来的に特定箇所のみログ復活可能
- システム監視が必要になった際の再導入は容易
- アプリケーションログとシステムログの分離を想定

## テスト手順

1. **バックエンドビルド・起動:**
   ```bash
   cd backend && ./gradlew compileJava
   cd backend && ./gradlew build
   cd backend && ./gradlew bootRun
   ```

2. **API動作確認:**
   - http://localhost:8080/swagger-ui.html でAPI仕様確認
   - 各エンドポイントが正常に応答することを確認
   - エラーハンドリングが適切に動作することを確認

3. **外部統合確認:**
   - GitHub API呼び出し機能のテスト
   - Notion API呼び出し機能のテスト
   - TogglTrack API呼び出し機能のテスト

4. **日報生成機能確認:**
   - 日報生成ロジックが正常動作することを確認
   - エラー時の適切なレスポンス返却を確認

## 影響範囲

**変更範囲：**
- バックエンド Java ファイル：10ファイル
- application層：UseCase 4ファイル
- infrastructure層：Repository 5ファイル  
- common層：GlobalExceptionHandler 1ファイル

**既存機能への影響：**
- 機能的な変更なし
- API仕様・レスポンス形式に変更なし
- エラーハンドリングロジックに変更なし
- 外部API統合に変更なし

**削除されたログ内容：**
- 日報生成・再生成の開始/完了ログ
- GitHub/Notion/TogglTrack API呼び出しログ
- データベース操作のデバッグログ
- 例外発生時の詳細ログ

**データベース変更：**
- なし

**パフォーマンスへの影響：**
- ログ出力処理の削除により微小な性能向上
- メモリ使用量の軽微な削減

## スクリーンショット

バックエンドのみの変更のため、UI変更はありません。

🤖 Generated with [Claude Code](https://claude.ai/code)