### PR TITLE
refactor: 共通DailyReportMapperクラスを追加して重複ロジックを削除

### DIFF
--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -52,8 +52,14 @@
           "required" : true
         },
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正または編集不可",
+          "404" : {
+            "description" : "日報が見つからない",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "500" : {
+            "description" : "サーバー内部エラー",
             "content" : {
               "application/json" : { }
             }
@@ -68,14 +74,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "日報が見つからない",
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "500" : {
-            "description" : "サーバー内部エラー",
+          "400" : {
+            "description" : "リクエストデータが不正または編集不可",
             "content" : {
               "application/json" : { }
             }
@@ -150,8 +150,8 @@
               }
             }
           },
-          "500" : {
-            "description" : "サーバー内部エラーまたはAI再生成失敗",
+          "400" : {
+            "description" : "リクエストデータが不正",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -170,8 +170,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "リクエストデータが不正",
+          "500" : {
+            "description" : "サーバー内部エラーまたはAI再生成失敗",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -200,6 +200,16 @@
           "required" : true
         },
         "responses" : {
+          "201" : {
+            "description" : "日報の生成に成功",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ReportGenerationResponseDto"
+                }
+              }
+            }
+          },
           "400" : {
             "description" : "リクエストデータが不正または指定日の日報が既に存在",
             "content" : {
@@ -212,16 +222,6 @@
           },
           "500" : {
             "description" : "サーバー内部エラーまたはAI生成失敗",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ReportGenerationResponseDto"
-                }
-              }
-            }
-          },
-          "201" : {
-            "description" : "日報の生成に成功",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -450,12 +450,6 @@
           "example" : "2024-12-31"
         } ],
         "responses" : {
-          "500" : {
-            "description" : "サーバー内部エラー",
-            "content" : {
-              "application/json" : { }
-            }
-          },
           "200" : {
             "description" : "日報の取得に成功",
             "content" : {
@@ -468,6 +462,12 @@
           },
           "400" : {
             "description" : "リクエストパラメータが不正",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "500" : {
+            "description" : "サーバー内部エラー",
             "content" : {
               "application/json" : { }
             }
@@ -502,22 +502,6 @@
           }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "日報の取得に成功",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/DailyReportDto"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "指定された日付の日報が見つからない",
-            "content" : {
-              "application/json" : { }
-            }
-          },
           "400" : {
             "description" : "日付形式が不正",
             "content" : {
@@ -528,6 +512,22 @@
             "description" : "サーバー内部エラー",
             "content" : {
               "application/json" : { }
+            }
+          },
+          "404" : {
+            "description" : "指定された日付の日報が見つからない",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "200" : {
+            "description" : "日報の取得に成功",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DailyReportDto"
+                }
+              }
             }
           }
         }

--- a/backend/src/main/java/com/example/backend/application/usecases/reports/ReportGenerationUseCase.java
+++ b/backend/src/main/java/com/example/backend/application/usecases/reports/ReportGenerationUseCase.java
@@ -1,6 +1,7 @@
 package com.example.backend.application.usecases.reports;
 
 import com.example.backend.application.dto.reports.DailyReportDto;
+import com.example.backend.common.util.DailyReportMapper;
 import com.example.backend.presentation.dto.reports.DailyReportUpdateRequestDto;
 import com.example.backend.presentation.dto.reports.ReportGenerationRequestDto;
 import com.example.backend.presentation.dto.reports.ReportGenerationResponseDto;
@@ -28,6 +29,7 @@ public class ReportGenerationUseCase {
     private final IReportGenerationService reportGenerationService;
     private final ReportUseCase reportUseCase;
     private final IDailyReportRepository dailyReportRepository;
+    private final DailyReportMapper dailyReportMapper;
     
     /**
      * 新規日報を生成する
@@ -83,7 +85,7 @@ public class ReportGenerationUseCase {
                     .build();
             
             DailyReport savedReport = dailyReportRepository.save(report);
-            DailyReportDto createdReport = convertToDto(savedReport);
+            DailyReportDto createdReport = dailyReportMapper.toDto(savedReport);
             
             
             return ReportGenerationResponseDto.success(
@@ -212,22 +214,4 @@ public class ReportGenerationUseCase {
         }
     }
     
-    /**
-     * DailyReportエンティティをDTOに変換
-     * 
-     * @param report 日報エンティティ
-     * @return 日報DTO
-     */
-    private DailyReportDto convertToDto(DailyReport report) {
-        return DailyReportDto.builder()
-                .id(report.getId())
-                .userId(report.getUserId())
-                .reportDate(report.getReportDate())
-                .rawData(report.getRawData())
-                .finalContent(report.getFinalContent())
-                .additionalNotes(report.getAdditionalNotes())
-                .createdAt(report.getCreatedAt())
-                .updatedAt(report.getUpdatedAt())
-                .build();
-    }
 }

--- a/backend/src/main/java/com/example/backend/application/usecases/reports/ReportUseCase.java
+++ b/backend/src/main/java/com/example/backend/application/usecases/reports/ReportUseCase.java
@@ -1,6 +1,7 @@
 package com.example.backend.application.usecases.reports;
 
 import com.example.backend.application.dto.reports.DailyReportDto;
+import com.example.backend.common.util.DailyReportMapper;
 import com.example.backend.domain.reports.DailyReport;
 import com.example.backend.domain.reports.IDailyReportRepository;
 import com.example.backend.presentation.dto.reports.DailyReportListResponseDto;
@@ -15,7 +16,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * 日報ユースケース
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 public class ReportUseCase {
     
     private final IDailyReportRepository dailyReportRepository;
+    private final DailyReportMapper dailyReportMapper;
     
     
     /**
@@ -58,7 +59,7 @@ public class ReportUseCase {
                 .build();
         
         DailyReport saved = dailyReportRepository.save(updatedReport);
-        return convertToDto(saved);
+        return dailyReportMapper.toDto(saved);
     }
     
     
@@ -80,9 +81,7 @@ public class ReportUseCase {
             reports = dailyReportRepository.findByUserId(userId);
         }
         
-        List<DailyReportDto> reportDtos = reports.stream()
-                .map(this::convertToDto)
-                .collect(Collectors.toList());
+        List<DailyReportDto> reportDtos = dailyReportMapper.toDtoList(reports);
         
         String dateRange = buildDateRangeString(startDate, endDate);
         
@@ -103,7 +102,7 @@ public class ReportUseCase {
     @Transactional(readOnly = true)
     public Optional<DailyReportDto> getReportByDate(UUID userId, LocalDate date) {
         return dailyReportRepository.findByUserIdAndDate(userId, date)
-                .map(this::convertToDto);
+                .map(dailyReportMapper::toDto);
     }
     
     
@@ -118,24 +117,6 @@ public class ReportUseCase {
         return dailyReportRepository.deleteById(reportId);
     }
     
-    /**
-     * DailyReportエンティティをDTOに変換
-     * 
-     * @param report 日報エンティティ
-     * @return 日報DTO
-     */
-    private DailyReportDto convertToDto(DailyReport report) {
-        return DailyReportDto.builder()
-                .id(report.getId())
-                .userId(report.getUserId())
-                .reportDate(report.getReportDate())
-                .rawData(report.getRawData())
-                .finalContent(report.getFinalContent())
-                .additionalNotes(report.getAdditionalNotes())
-                .createdAt(report.getCreatedAt())
-                .updatedAt(report.getUpdatedAt())
-                .build();
-    }
     
     /**
      * 日付範囲文字列を構築

--- a/backend/src/main/java/com/example/backend/common/util/DailyReportMapper.java
+++ b/backend/src/main/java/com/example/backend/common/util/DailyReportMapper.java
@@ -1,0 +1,49 @@
+package com.example.backend.common.util;
+
+import com.example.backend.application.dto.reports.DailyReportDto;
+import com.example.backend.domain.reports.DailyReport;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * DailyReportエンティティとDTOの変換を担当するMapper
+ * 重複する変換ロジックを統一化
+ */
+@Component
+@RequiredArgsConstructor
+public class DailyReportMapper {
+    
+    /**
+     * DailyReportエンティティをDTOに変換
+     * 
+     * @param report 日報エンティティ
+     * @return 日報DTO
+     */
+    public DailyReportDto toDto(DailyReport report) {
+        return DailyReportDto.builder()
+                .id(report.getId())
+                .userId(report.getUserId())
+                .reportDate(report.getReportDate())
+                .rawData(report.getRawData())
+                .finalContent(report.getFinalContent())
+                .additionalNotes(report.getAdditionalNotes())
+                .createdAt(report.getCreatedAt())
+                .updatedAt(report.getUpdatedAt())
+                .build();
+    }
+    
+    /**
+     * DailyReportエンティティのリストをDTOリストに変換
+     * 
+     * @param reports 日報エンティティリスト
+     * @return 日報DTOリスト
+     */
+    public List<DailyReportDto> toDtoList(List<DailyReport> reports) {
+        return reports.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/test/java/com/example/backend/application/usecases/ReportGenerationUseCaseTest.java
+++ b/backend/src/test/java/com/example/backend/application/usecases/ReportGenerationUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.example.backend.application.usecases;
 
 import com.example.backend.application.dto.reports.DailyReportDto;
+import com.example.backend.common.util.DailyReportMapper;
 import com.example.backend.presentation.dto.reports.ReportGenerationRequestDto;
 import com.example.backend.presentation.dto.reports.ReportGenerationResponseDto;
 import com.example.backend.application.usecases.reports.ReportGenerationUseCase;
@@ -37,6 +38,9 @@ class ReportGenerationUseCaseTest {
     @Mock
     private IDailyReportRepository dailyReportRepository;
     
+    @Mock
+    private DailyReportMapper dailyReportMapper;
+    
     private ReportGenerationUseCase reportGenerationUseCase;
     
     @BeforeEach
@@ -44,7 +48,8 @@ class ReportGenerationUseCaseTest {
         reportGenerationUseCase = new ReportGenerationUseCase(
             reportGenerationService,
             reportUseCase,
-            dailyReportRepository
+            dailyReportRepository,
+            dailyReportMapper
         );
     }
     
@@ -82,6 +87,19 @@ class ReportGenerationUseCaseTest {
             
         when(dailyReportRepository.save(any(DailyReport.class)))
             .thenReturn(savedReport);
+        
+        DailyReportDto reportDto = DailyReportDto.builder()
+            .id(reportId)
+            .userId(userId)
+            .reportDate(reportDate)
+            .finalContent("生成された日報コンテンツ")
+            .additionalNotes("テスト用追加メモ")
+            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
+            .build();
+            
+        when(dailyReportMapper.toDto(savedReport))
+            .thenReturn(reportDto);
         
         // When
         ReportGenerationResponseDto response = reportGenerationUseCase.generateReport(request);


### PR DESCRIPTION
## PR に関連する issue

バックエンドロジックの簡潔化として、重複する変換ロジックを統一化する作業です。

## やったこと

### 重複ロジックの統一化
- `common/util/DailyReportMapper.java` を新規作成
- `ReportUseCase` と `ReportGenerationUseCase` で重複していた `convertToDto()` メソッドを削除
- 両クラスで `DailyReportMapper` を使用するように修正

### 具体的な変更
1. **DailyReportMapper作成**: エンティティ↔DTO変換を統一
2. **ReportUseCase修正**: 重複する `convertToDto()` を削除し `dailyReportMapper.toDto()` を使用
3. **ReportGenerationUseCase修正**: 同様に重複処理を削除
4. **テストファイル更新**: 新しい依存関係に対応

## レビュー情報

### 特にレビューしてほしいところ
- `DailyReportMapper` の設計が適切か
- 依存関係注入が正しく行われているか
- 使用箇所で適切にMapperが呼ばれているか

### 実装の思考プロセス
- **問題**: `ReportUseCase` と `ReportGenerationUseCase` で全く同じ `convertToDto()` メソッドが重複
- **解決策**: 共通Mapperクラスを作成し、変換ロジックを一元化
- **配置場所**: `common/util/` 配下に配置して他の共通処理と統一
- **設計**: `@Component` として Spring に管理させ、DI で使用

## テスト手順

```bash
# 1. バックエンドビルド確認
cd backend && ./gradlew build -x test

# 2. ビルド成功を確認
# BUILD SUCCESSFUL が表示されることを確認

# 3. API動作確認（オプション）
./gradlew bootRun
# Swagger UI: http://localhost:8080/swagger-ui.html でAPI確認
```

## 影響範囲

### 変更範囲
- `ReportUseCase`: `convertToDto()` 削除、`DailyReportMapper` 使用
- `ReportGenerationUseCase`: 同上
- `DailyReportMapper`: 新規追加

### 既存機能への影響
- **機能的な影響なし**: 変換ロジックは同一のため API レスポンスに変更なし
- **構造的改善**: 保守性とテストしやすさが向上

### データベース変更
- なし

## 効果

- **重複コード削除**: 約20行の重複コードを削除
- **保守性向上**: DTO構造変更時の修正箇所を1箇所に集約
- **責務明確化**: 変換処理の責務をMapperクラスに統一

🤖 Generated with [Claude Code](https://claude.ai/code)