### PR TITLE
refactor: ReportControllerのUser-ID処理をX-User-Idヘッダーに統一

### DIFF
--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -49,8 +49,8 @@
           "required" : true
         },
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
+          "500" : {
+            "description" : "サーバー内部エラー"
           },
           "200" : {
             "description" : "日報の更新に成功",
@@ -62,8 +62,8 @@
               }
             }
           },
-          "500" : {
-            "description" : "サーバー内部エラー"
+          "400" : {
+            "description" : "リクエストデータが不正"
           },
           "404" : {
             "description" : "リソースが見つからない"
@@ -89,11 +89,11 @@
           "204" : {
             "description" : "日報の削除に成功"
           },
-          "400" : {
-            "description" : "リクエストデータが不正"
-          },
           "500" : {
             "description" : "サーバー内部エラー"
+          },
+          "400" : {
+            "description" : "リクエストデータが不正"
           },
           "404" : {
             "description" : "リソースが見つからない"
@@ -128,8 +128,8 @@
           "required" : true
         },
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
+          "500" : {
+            "description" : "サーバー内部エラー"
           },
           "200" : {
             "description" : "日報の再生成に成功",
@@ -141,8 +141,8 @@
               }
             }
           },
-          "500" : {
-            "description" : "サーバー内部エラー"
+          "400" : {
+            "description" : "リクエストデータが不正"
           },
           "404" : {
             "description" : "リソースが見つからない"
@@ -167,8 +167,8 @@
           "required" : true
         },
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
+          "500" : {
+            "description" : "サーバー内部エラー"
           },
           "201" : {
             "description" : "日報の生成に成功",
@@ -180,8 +180,8 @@
               }
             }
           },
-          "500" : {
-            "description" : "サーバー内部エラー"
+          "400" : {
+            "description" : "リクエストデータが不正"
           }
         }
       }
@@ -213,12 +213,6 @@
           "required" : true
         },
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
-          },
-          "500" : {
-            "description" : "サーバーエラー"
-          },
           "201" : {
             "description" : "認証情報の作成に成功",
             "content" : {
@@ -228,6 +222,12 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "リクエストデータが不正"
+          },
+          "500" : {
+            "description" : "サーバーエラー"
           }
         }
       }
@@ -259,12 +259,6 @@
           "required" : true
         },
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
-          },
-          "500" : {
-            "description" : "サーバーエラー"
-          },
           "201" : {
             "description" : "認証情報の作成に成功",
             "content" : {
@@ -274,6 +268,12 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "リクエストデータが不正"
+          },
+          "500" : {
+            "description" : "サーバーエラー"
           }
         }
       }
@@ -305,12 +305,6 @@
           "required" : true
         },
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
-          },
-          "500" : {
-            "description" : "サーバーエラー"
-          },
           "201" : {
             "description" : "認証情報の作成に成功",
             "content" : {
@@ -320,6 +314,12 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "リクエストデータが不正"
+          },
+          "500" : {
+            "description" : "サーバーエラー"
           }
         }
       }
@@ -361,8 +361,8 @@
           "example" : "2024-12-31"
         } ],
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
+          "500" : {
+            "description" : "サーバー内部エラー"
           },
           "200" : {
             "description" : "日報の取得に成功",
@@ -374,8 +374,8 @@
               }
             }
           },
-          "500" : {
-            "description" : "サーバー内部エラー"
+          "400" : {
+            "description" : "リクエストデータが不正"
           }
         }
       }
@@ -407,8 +407,8 @@
           }
         } ],
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
+          "500" : {
+            "description" : "サーバー内部エラー"
           },
           "200" : {
             "description" : "日報の取得に成功",
@@ -420,8 +420,8 @@
               }
             }
           },
-          "500" : {
-            "description" : "サーバー内部エラー"
+          "400" : {
+            "description" : "リクエストデータが不正"
           },
           "404" : {
             "description" : "リソースが見つからない"
@@ -436,9 +436,6 @@
         "description" : "ToggleTrack API接続をテストして、アクセス権限を確認します",
         "operationId" : "testConnection",
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
-          },
           "200" : {
             "description" : "接続テストが正常に完了",
             "content" : {
@@ -448,6 +445,9 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "リクエストデータが不正"
           },
           "500" : {
             "description" : "サーバーエラー"
@@ -501,9 +501,6 @@
         "description" : "Notion API接続をテストして、アクセス権限を確認します",
         "operationId" : "testConnection_1",
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
-          },
           "200" : {
             "description" : "接続テストが正常に完了",
             "content" : {
@@ -513,6 +510,9 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "リクエストデータが不正"
           },
           "500" : {
             "description" : "サーバーエラー"
@@ -585,9 +585,6 @@
           "example" : "Hello-World"
         } ],
         "responses" : {
-          "400" : {
-            "description" : "リクエストデータが不正"
-          },
           "200" : {
             "description" : "接続テストが正常に完了",
             "content" : {
@@ -597,6 +594,9 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "リクエストデータが不正"
           },
           "500" : {
             "description" : "サーバーエラー"
@@ -660,11 +660,11 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "認証情報が見つからない"
-          },
           "204" : {
             "description" : "認証情報の削除に成功"
+          },
+          "404" : {
+            "description" : "認証情報が見つからない"
           },
           "500" : {
             "description" : "サーバーエラー"
@@ -689,11 +689,11 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "認証情報が見つからない"
-          },
           "204" : {
             "description" : "認証情報の削除に成功"
+          },
+          "404" : {
+            "description" : "認証情報が見つからない"
           },
           "500" : {
             "description" : "サーバーエラー"
@@ -718,11 +718,11 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "認証情報が見つからない"
-          },
           "204" : {
             "description" : "認証情報の削除に成功"
+          },
+          "404" : {
+            "description" : "認証情報が見つからない"
           },
           "500" : {
             "description" : "サーバーエラー"

--- a/backend/src/main/java/com/example/backend/presentation/controllers/reports/ReportController.java
+++ b/backend/src/main/java/com/example/backend/presentation/controllers/reports/ReportController.java
@@ -60,7 +60,7 @@ public class ReportController {
     @CommonApiResponses.StandardErrorResponses
     public ResponseEntity<DailyReportListResponseDto> getReports(
             @Parameter(description = "ユーザーID", required = true)
-            @RequestParam UUID userId,
+            @RequestHeader("X-User-Id") UUID userId,
             
             @Parameter(description = "フィルタリング開始日 (YYYY-MM-DD形式)", example = "2024-01-01")
             @RequestParam(required = false) 
@@ -95,7 +95,7 @@ public class ReportController {
             @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             
             @Parameter(description = "ユーザーID", required = true)
-            @RequestParam UUID userId
+            @RequestHeader("X-User-Id") UUID userId
     ) {
         Optional<DailyReportDto> report = reportUseCase.getReportByDate(userId, date);
         return report.map(ResponseEntity::ok)
@@ -171,10 +171,12 @@ public class ReportController {
     })
     @CommonApiResponses.StandardErrorResponses
     public ResponseEntity<ReportGenerationResponseDto> generateReport(
+            @Parameter(description = "ユーザーID", required = true)
+            @RequestHeader("X-User-Id") UUID userId,
             @Parameter(description = "日報生成リクエスト", required = true)
             @RequestBody ReportGenerationRequestDto request
     ) {
-        ReportGenerationResponseDto response = reportGenerationUseCase.generateReport(request);
+        ReportGenerationResponseDto response = reportGenerationUseCase.generateReport(userId, request);
         
         if (response.isSuccess()) {
             return ResponseEntity.status(201).body(response);

--- a/backend/src/main/java/com/example/backend/presentation/dto/reports/ReportGenerationRequestDto.java
+++ b/backend/src/main/java/com/example/backend/presentation/dto/reports/ReportGenerationRequestDto.java
@@ -3,17 +3,16 @@ package com.example.backend.presentation.dto.reports;
 import lombok.Builder;
 import lombok.Getter;
 import java.time.LocalDate;
-import java.util.UUID;
 
 /**
  * 日報生成リクエストDTO
  * 新規日報生成時のリクエスト情報を転送するためのDTO
+ * userIdはHTTPヘッダー(X-User-Id)から取得されるため、リクエストボディには含まない
  */
 @Getter
 @Builder
 public class ReportGenerationRequestDto {
     
-    private final UUID userId;
     private final LocalDate reportDate;
     private final String additionalNotes;
     
@@ -23,7 +22,7 @@ public class ReportGenerationRequestDto {
      * @return すべての必須項目が設定されている場合true
      */
     public boolean isValid() {
-        return userId != null && reportDate != null;
+        return reportDate != null;
     }
     
 }


### PR DESCRIPTION
## PR に関連する issue

バックエンド全体でのUser-ID処理統一の最終ステップ
- フロントエンド PR #47 に対応するバックエンド側の統一
- システム全体での一貫したX-User-Id ヘッダー使用

## やったこと

このPRでは、ReportController の User-ID 処理を X-User-Id ヘッダーに統一し、バックエンド全体での User-ID 処理の一貫性を完成させました：

### 主要な変更内容

#### 1. ReportController エンドポイントの統一
- **GET /api/reports**: `@RequestParam UUID userId` → `@RequestHeader("X-User-Id") UUID userId`
- **GET /api/reports/{date}**: `@RequestParam UUID userId` → `@RequestHeader("X-User-Id") UUID userId`
- **POST /api/reports/generate**: X-User-Id ヘッダーの追加

#### 2. ReportGenerationRequestDto の簡素化
- **削除**: `private final UUID userId` フィールド
- **更新**: `isValid()` メソッドから userId チェックを除去
- **説明追加**: HTTPヘッダーから取得する旨のコメント

#### 3. ReportGenerationUseCase の更新
- **メソッドシグネチャ変更**: `generateReport(ReportGenerationRequestDto request)` → `generateReport(UUID userId, ReportGenerationRequestDto request)`
- **内部処理更新**: `request.getUserId()` の全呼び出しを `userId` パラメータに置換
- **エラーハンドリング**: 例外処理でのuserIdの適切な使用

## レビュー情報

特にレビューしてほしいところ：

- **API一貫性**: ReportController の全エンドポイントでX-User-Id ヘッダーが適切に使用されているか
- **下位互換性**: ReportGenerationUseCase のシグネチャ変更が適切に反映されているか  
- **フロントエンド連携**: PR #47 との整合性確保

## 実装の思考プロセス

### アプローチの選択理由

1. **段階的統一**: 認証情報API（PR #46）→ フロントエンド（PR #47）→ 日報API（本PR）の順序で統一
2. **DTO設計の改善**: リクエストボディからuserIdを除去し、HTTPヘッダーからの取得に統一
3. **UseCase層での明示的なパラメータ**: userIdを明示的に受け取ることで、データの流れを明確化

### 将来の拡張性への配慮

- **認証システム統合**: 将来的にJWT等の認証システム導入時も、ヘッダーベースのUser-ID取得は継続使用可能
- **API Gateway連携**: X-User-Id ヘッダーはAPI Gatewayでの統一認証・認可との親和性が高い
- **監査ログ**: 全APIでのユーザー操作トレーサビリティが統一的に実現

## テスト手順

1. **バックエンドビルド・起動**:
   ```bash
   cd backend && ./gradlew build && ./gradlew bootRun
   ```

2. **API確認**:
   - http://localhost:8080/swagger-ui.html で更新されたAPI仕様を確認
   - ReportController の全エンドポイントで X-User-Id ヘッダーが必須になっていることを確認

3. **統合テスト**:
   - フロントエンド PR #47 とあわせて、User-ID統一の動作確認
   - 日報生成・取得・更新の全フローでヘッダーベース認証が正常動作することを確認

## 影響範囲

### 変更の範囲
- **ReportController**: 全エンドポイントのUser-ID取得方法変更
- **ReportGenerationRequestDto**: userIdフィールドの削除  
- **ReportGenerationUseCase**: メソッドシグネチャとパラメータ使用の変更

### 既存機能への影響
- **破壊的変更**: ReportController APIのリクエスト形式変更
  - フロントエンド PR #47 で既に対応済み
- **UseCase層**: 下流への影響は限定的（インターフェースは保持）

### システム全体への効果
- **User-ID統一完了**: バックエンド全APIでX-User-Id ヘッダー使用に統一
- **セキュリティ向上**: クエリパラメータでの認証情報露出リスクを排除
- **API設計一貫性**: 全エンドポイントでの統一された認証方式

### データベース変更
- **変更なし**: データベーススキーマやデータへの影響はありません

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>